### PR TITLE
[T1451] - Fix: Muskathlon event ambassador

### DIFF
--- a/crowdfunding_compassion/models/sale_order_line.py
+++ b/crowdfunding_compassion/models/sale_order_line.py
@@ -37,13 +37,14 @@ class SaleOrderLine(models.Model):
         res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
 
         if hasattr(self, 'participant_id') and self.participant_id:
-            res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
-            analytic = self.participant_id.project_id.event_id.analytic_id
+            user_id = self.participant_id.partner_id.id
+            analytic_id = self.participant_id.project_id.event_id.analytic_id.id
+            crowdfunding_participant_id = self.participant_id.id,
             res.update(
                 {
-                    "user_id": self.participant_id.partner_id.id,
-                    "analytic_account_id": analytic.id,
-                    "crowdfunding_participant_id": self.participant_id.id,
+                    "user_id": user_id,
+                    "analytic_account_id": analytic_id,
+                    "crowdfunding_participant_id": crowdfunding_participant_id,
                 }
             )
         return res

--- a/crowdfunding_compassion/models/sale_order_line.py
+++ b/crowdfunding_compassion/models/sale_order_line.py
@@ -35,16 +35,14 @@ class SaleOrderLine(models.Model):
 
     def _prepare_invoice_line(self, **optional_values):
         res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
-
-        if hasattr(self, 'participant_id') and self.participant_id:
-            user_id = self.participant_id.partner_id.id
-            analytic_id = self.participant_id.project_id.event_id.analytic_id.id
-            crowdfunding_participant_id = self.participant_id.id,
+        participant = getattr(self, 'participant_id', False)
+        if participant:
             res.update(
                 {
-                    "user_id": user_id,
-                    "analytic_account_id": analytic_id,
-                    "crowdfunding_participant_id": crowdfunding_participant_id,
+                    "user_id": participant.partner_id.id,
+                    "analytic_account_id":
+                        participant.project_id.event_id.analytic_id.id,
+                    "crowdfunding_participant_id": participant.id,
                 }
             )
         return res

--- a/crowdfunding_compassion/models/sale_order_line.py
+++ b/crowdfunding_compassion/models/sale_order_line.py
@@ -8,7 +8,7 @@
 #
 ##############################################################################
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class SaleOrderLine(models.Model):
@@ -34,14 +34,17 @@ class SaleOrderLine(models.Model):
         return super().get_donation_description(product)
 
     def _prepare_invoice_line(self, **optional_values):
-        # Propagate ambassador and event to invoice line
-        res = super()._prepare_invoice_line(**optional_values)
-        analytic = self.participant_id.project_id.event_id.analytic_id
-        res.update(
-            {
-                "user_id": self.participant_id.partner_id.id,
-                "analytic_account_id": analytic.id,
-                "crowdfunding_participant_id": self.participant_id.id,
-            }
-        )
+        res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
+
+        if hasattr(self, 'participant_id') and self.participant_id:
+            # Propagate ambassador and event to invoice line for module_a
+            res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
+            analytic = self.participant_id.project_id.event_id.analytic_id
+            res.update(
+                {
+                    "user_id": self.participant_id.partner_id.id,
+                    "analytic_account_id": analytic.id,
+                    "crowdfunding_participant_id": self.participant_id.id,
+                }
+            )
         return res

--- a/crowdfunding_compassion/models/sale_order_line.py
+++ b/crowdfunding_compassion/models/sale_order_line.py
@@ -37,7 +37,6 @@ class SaleOrderLine(models.Model):
         res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
 
         if hasattr(self, 'participant_id') and self.participant_id:
-            # Propagate ambassador and event to invoice line for module_a
             res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
             analytic = self.participant_id.project_id.event_id.analytic_id
             res.update(

--- a/website_event_compassion/models/sale_order_line.py
+++ b/website_event_compassion/models/sale_order_line.py
@@ -8,7 +8,7 @@
 #
 ##############################################################################
 
-from odoo import _, fields, models
+from odoo import _, fields, models, api
 
 
 class SaleOrderLine(models.Model):
@@ -32,13 +32,17 @@ class SaleOrderLine(models.Model):
         return super().get_donation_description(product)
 
     def _prepare_invoice_line(self, **optional_values):
-        # Propagate ambassador and event to invoice line
-        res = super()._prepare_invoice_line(**optional_values)
-        analytic = self.registration_id.compassion_event_id.analytic_id
-        res.update(
-            {
-                "user_id": self.registration_id.partner_id.id,
-                "analytic_account_id": analytic.id,
-            }
-        )
+
+        res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
+
+        if hasattr(self, 'registration_id') and self.registration_id:
+            # Propagate ambassador and event to invoice line for module_b
+            res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
+            analytic = self.registration_id.compassion_event_id.analytic_id
+            res.update(
+                {
+                    "user_id": self.registration_id.partner_id.id,
+                    "analytic_account_id": analytic.id,
+                }
+            )
         return res

--- a/website_event_compassion/models/sale_order_line.py
+++ b/website_event_compassion/models/sale_order_line.py
@@ -36,7 +36,6 @@ class SaleOrderLine(models.Model):
         res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
 
         if hasattr(self, 'registration_id') and self.registration_id:
-            # Propagate ambassador and event to invoice line for module_b
             res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
             analytic = self.registration_id.compassion_event_id.analytic_id
             res.update(

--- a/website_event_compassion/models/sale_order_line.py
+++ b/website_event_compassion/models/sale_order_line.py
@@ -32,16 +32,15 @@ class SaleOrderLine(models.Model):
         return super().get_donation_description(product)
 
     def _prepare_invoice_line(self, **optional_values):
-
         res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
 
         if hasattr(self, 'registration_id') and self.registration_id:
-            res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
-            analytic = self.registration_id.compassion_event_id.analytic_id
+            user_id = self.registration_id.partner_id.id
+            analytic_id = self.registration_id.compassion_event_id.analytic_id.id
             res.update(
                 {
-                    "user_id": self.registration_id.partner_id.id,
-                    "analytic_account_id": analytic.id,
+                    "user_id": user_id,
+                    "analytic_account_id": analytic_id,
                 }
             )
         return res

--- a/website_event_compassion/models/sale_order_line.py
+++ b/website_event_compassion/models/sale_order_line.py
@@ -32,15 +32,13 @@ class SaleOrderLine(models.Model):
         return super().get_donation_description(product)
 
     def _prepare_invoice_line(self, **optional_values):
-        res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
-
-        if hasattr(self, 'registration_id') and self.registration_id:
-            user_id = self.registration_id.partner_id.id
-            analytic_id = self.registration_id.compassion_event_id.analytic_id.id
+        res = super()._prepare_invoice_line(**optional_values)
+        registration = getattr(self, 'registration_id', False)
+        if registration:
             res.update(
                 {
-                    "user_id": user_id,
-                    "analytic_account_id": analytic_id,
+                    "user_id": registration.partner_id.id,
+                    "analytic_account_id": registration.compassion_event_id.analytic_id.id,
                 }
             )
         return res


### PR DESCRIPTION
Event ambassador was rewritten by crowdfunding, context was constantly rewrite and I didn't find a way to pass it correctly. So I use another way, working as well. Parameters are unique for each module, crowdfunding (by using participant_id) and event (by using registration_id). In any case, one of them will be null.