### PR TITLE
T1599 - Muskathlon Website - Participant’s chosen discipline

### DIFF
--- a/muskathlon/__manifest__.py
+++ b/muskathlon/__manifest__.py
@@ -60,6 +60,8 @@
         "templates/muskathlon_page.xml",
         "templates/muskathlon_registration_form.xml",
         "templates/muskathlon_order_material.xml",
+        "templates/muskathlon_participants_list.xml",
+        "templates/muskathlon_participant_page.xml",
         "templates/my_tasks_forms.xml",
         "templates/donation_result.xml",
         "templates/assets.xml",

--- a/muskathlon/static/src/css/custom.css
+++ b/muskathlon/static/src/css/custom.css
@@ -33,7 +33,6 @@
   height: 38px;
 }
 
-
 .sport_icon_sm {
   height: 25px;
   width: 25px;

--- a/muskathlon/static/src/css/custom.css
+++ b/muskathlon/static/src/css/custom.css
@@ -32,3 +32,9 @@
 .sport_icon.walk {
   height: 38px;
 }
+
+
+.sport_icon_sm {
+  height: 25px;
+  width: 25px;
+}

--- a/muskathlon/templates/muskathlon_participant_page.xml
+++ b/muskathlon/templates/muskathlon_participant_page.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="muskathlon_participant_page" inherit_id="website_event_compassion.participant_page">
+        <xpath expr="//div[@class='container']//figure/../.." position="after">
+            <t t-set="discipline" t-value="registration.sport_discipline_id.with_context(lang='en_US')" />
+            <t t-set="discipline_loc" t-value="registration.sport_discipline_id" />
+
+            <div t-if="discipline.sport == 'Bike'" class="mb-4" t-att-title="discipline_loc.name" align="center">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/biking.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+            <div t-if="discipline.sport == 'Running'" class="mb-4" t-att-title="discipline_loc.name" align="center">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/running.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+            <div t-if="discipline.sport == 'Walking'" class="mb-4" t-att-title="discipline_loc.name" align="center">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/walking.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+            <div t-if="discipline.sport == 'Climbing'" class="mb-4" t-att-title="discipline_loc.name" align="center">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/climbing.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/muskathlon/templates/muskathlon_participant_page.xml
+++ b/muskathlon/templates/muskathlon_participant_page.xml
@@ -1,25 +1,74 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="muskathlon_participant_page" inherit_id="website_event_compassion.participant_page">
+    <template
+    id="muskathlon_participant_page"
+    inherit_id="website_event_compassion.participant_page"
+  >
         <xpath expr="//div[@class='container']//figure/../.." position="after">
-            <t t-set="discipline" t-value="registration.sport_discipline_id.with_context(lang='en_US')" />
-            <t t-set="discipline_loc" t-value="registration.sport_discipline_id" />
+            <t
+        t-set="discipline"
+        t-value="registration.sport_discipline_id.with_context(lang='en_US')"
+      />
+            <t
+        t-set="discipline_loc"
+        t-value="registration.sport_discipline_id"
+      />
 
-            <div t-if="discipline.sport == 'Bike'" class="mb-4" t-att-title="discipline_loc.name" align="center">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/biking.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Bike'"
+        class="mb-4"
+        t-att-title="discipline_loc.name"
+        align="center"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/biking.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
-            <div t-if="discipline.sport == 'Running'" class="mb-4" t-att-title="discipline_loc.name" align="center">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/running.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Running'"
+        class="mb-4"
+        t-att-title="discipline_loc.name"
+        align="center"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/running.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
-            <div t-if="discipline.sport == 'Walking'" class="mb-4" t-att-title="discipline_loc.name" align="center">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/walking.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Walking'"
+        class="mb-4"
+        t-att-title="discipline_loc.name"
+        align="center"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/walking.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
-            <div t-if="discipline.sport == 'Climbing'" class="mb-4" t-att-title="discipline_loc.name" align="center">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/climbing.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Climbing'"
+        class="mb-4"
+        t-att-title="discipline_loc.name"
+        align="center"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/climbing.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
         </xpath>
     </template>

--- a/muskathlon/templates/muskathlon_participants_list.xml
+++ b/muskathlon/templates/muskathlon_participants_list.xml
@@ -1,25 +1,70 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="muskathlon_participants_list" inherit_id="website_event_compassion.event_participants_list">
+    <template
+    id="muskathlon_participants_list"
+    inherit_id="website_event_compassion.event_participants_list"
+  >
         <xpath expr="//div[@class='card-title']/.." position="after">
-            <t t-set="discipline" t-value="registration.sport_discipline_id.with_context(lang='en_US')" />
-            <t t-set="discipline_loc" t-value="registration.sport_discipline_id" />
+            <t
+        t-set="discipline"
+        t-value="registration.sport_discipline_id.with_context(lang='en_US')"
+      />
+            <t
+        t-set="discipline_loc"
+        t-value="registration.sport_discipline_id"
+      />
 
-            <div t-if="discipline.sport == 'Bike'" class="mb-3" t-att-title="discipline_loc.name">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/biking.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Bike'"
+        class="mb-3"
+        t-att-title="discipline_loc.name"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/biking.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
-            <div t-if="discipline.sport == 'Running'" class="mb-3" t-att-title="discipline_loc.name">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/running.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Running'"
+        class="mb-3"
+        t-att-title="discipline_loc.name"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/running.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
-            <div t-if="discipline.sport == 'Walking'" class="mb-3" t-att-title="discipline_loc.name">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/walking.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Walking'"
+        class="mb-3"
+        t-att-title="discipline_loc.name"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/walking.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
-            <div t-if="discipline.sport == 'Climbing'" class="mb-3" t-att-title="discipline_loc.name">
-                <img class="sport_icon_sm" src="/muskathlon/static/src/data/climbing.png" />
-                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            <div
+        t-if="discipline.sport == 'Climbing'"
+        class="mb-3"
+        t-att-title="discipline_loc.name"
+      >
+                <img
+          class="sport_icon_sm"
+          src="/muskathlon/static/src/data/climbing.png"
+        />
+                <span class="distance_km"><t
+            t-esc="discipline.distance_km"
+          />km</span>
             </div>
         </xpath>
     </template>

--- a/muskathlon/templates/muskathlon_participants_list.xml
+++ b/muskathlon/templates/muskathlon_participants_list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="muskathlon_participants_list" inherit_id="website_event_compassion.event_participants_list">
+        <xpath expr="//div[@class='card-title']/.." position="after">
+            <t t-set="discipline" t-value="registration.sport_discipline_id.with_context(lang='en_US')" />
+            <t t-set="discipline_loc" t-value="registration.sport_discipline_id" />
+
+            <div t-if="discipline.sport == 'Bike'" class="mb-3" t-att-title="discipline_loc.name">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/biking.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+            <div t-if="discipline.sport == 'Running'" class="mb-3" t-att-title="discipline_loc.name">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/running.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+            <div t-if="discipline.sport == 'Walking'" class="mb-3" t-att-title="discipline_loc.name">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/walking.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+            <div t-if="discipline.sport == 'Climbing'" class="mb-3" t-att-title="discipline_loc.name">
+                <img class="sport_icon_sm" src="/muskathlon/static/src/data/climbing.png" />
+                <span class="distance_km"><t t-esc="discipline.distance_km" />km</span>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION

- Main page:
![image](https://github.com/user-attachments/assets/46adf2c5-dee1-4b7b-9c24-b5dd39568876)

- Participant page:
![image](https://github.com/user-attachments/assets/01f77648-0005-4b18-85ea-ab9fc595f572)


## Task

Nowhere on the Muskathlon website can it be seen which discipline the participant has chosen to do (it’s not on the main page, and not there when you click on the participant’s profile to donate.
Can we please make this visible at least on their profile, but maybe also from the main page?