### PR TITLE
T1613 Muskathlon Profile parts missing

### DIFF
--- a/muskathlon/__manifest__.py
+++ b/muskathlon/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Muskathlon",
-    "version": "14.0.1.2.01",
+    "version": "14.0.1.2.1",
     "category": "Reports",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/muskathlon/__manifest__.py
+++ b/muskathlon/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Muskathlon",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.2.01",
     "category": "Reports",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/muskathlon/data/event_registration_task.xml
+++ b/muskathlon/data/event_registration_task.xml
@@ -14,25 +14,25 @@
         </record>
         <record id="task_criminal" model="event.registration.task">
             <field name="name">Upload Criminal Record</field>
-            <field name="sequence">3</field>
+            <field name="sequence">6</field>
             <field name="stage_id" ref="stage_fill_profile" />
             <field name="website_published" eval="True" />
         </record>
         <record id="task_flight_details" model="event.registration.task">
             <field name="name">Give flight details</field>
-            <field name="sequence">4</field>
+            <field name="sequence">3</field>
             <field name="stage_id" ref="stage_fill_profile" />
             <field name="website_published" eval="True" />
         </record>
         <record id="task_medical" model="event.registration.task">
             <field name="name">Fill medical survey</field>
-            <field name="sequence">5</field>
+            <field name="sequence">4</field>
             <field name="stage_id" ref="stage_fill_profile" />
             <field name="website_published" eval="True" />
         </record>
         <record id="task_sign_child_protection" model="event.registration.task">
             <field name="name">Sign child protection agreement</field>
-            <field name="sequence">6</field>
+            <field name="sequence">5</field>
             <field name="stage_id" ref="stage_fill_profile" />
             <field name="website_published" eval="True" />
             <field

--- a/muskathlon/migrations/14.0.1.2.1/post-migrate.py
+++ b/muskathlon/migrations/14.0.1.2.1/post-migrate.py
@@ -1,13 +1,12 @@
 from openupgradelib import openupgrade
 from odoo import api, SUPERUSER_ID
 
-event_registration_task_ids = [
-    "task_passport",
-    "task_criminal",
-    "task_flight_details",
-    "task_medical",
-    "task_sign_child_protection",
-]
+muskathlon_task_sequence = {
+    "task_criminal": 6,
+    "task_flight_details": 3,
+    "task_medical": 4,
+    "task_sign_child_protection": 5,
+}
 
 
 def migrate(cr, version):

--- a/muskathlon/migrations/14.0.1.2.1/post-migrate.py
+++ b/muskathlon/migrations/14.0.1.2.1/post-migrate.py
@@ -1,0 +1,33 @@
+from openupgradelib import openupgrade
+from odoo import api, SUPERUSER_ID
+
+event_registration_task_ids = [
+    "task_passport",
+    "task_criminal",
+    "task_flight_details",
+    "task_medical",
+    "task_sign_child_protection",
+]
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    openupgrade.set_xml_ids_noupdate_value(
+        env,
+        "muskathlon",
+        event_registration_task_ids,
+        False
+    )
+
+    env.ref('muskathlon.task_criminal').sequence = 6
+    env.ref('muskathlon.task_flight_details').sequence = 3
+    env.ref('muskathlon.task_medical').sequence = 4
+    env.ref('muskathlon.task_sign_child_protection').sequence = 5
+
+    openupgrade.set_xml_ids_noupdate_value(
+        env,
+        "muskathlon",
+        event_registration_task_ids,
+        True
+    )

--- a/muskathlon/migrations/14.0.1.2.1/post-migrate.py
+++ b/muskathlon/migrations/14.0.1.2.1/post-migrate.py
@@ -9,24 +9,8 @@ muskathlon_task_sequence = {
 }
 
 
-def migrate(cr, version):
-    env = api.Environment(cr, SUPERUSER_ID, {})
+@openupgrade.migrate()
+def migrate(env, version):
+    for task_id, task_sequence in muskathlon_task_sequence.items():
+        env.ref(f"muskathlon.{task_id}").sequence = task_sequence
 
-    openupgrade.set_xml_ids_noupdate_value(
-        env,
-        "muskathlon",
-        event_registration_task_ids,
-        False
-    )
-
-    env.ref('muskathlon.task_criminal').sequence = 6
-    env.ref('muskathlon.task_flight_details').sequence = 3
-    env.ref('muskathlon.task_medical').sequence = 4
-    env.ref('muskathlon.task_sign_child_protection').sequence = 5
-
-    openupgrade.set_xml_ids_noupdate_value(
-        env,
-        "muskathlon",
-        event_registration_task_ids,
-        True
-    )

--- a/muskathlon/migrations/14.0.1.2.1/post-migrate.py
+++ b/muskathlon/migrations/14.0.1.2.1/post-migrate.py
@@ -1,5 +1,4 @@
 from openupgradelib import openupgrade
-from odoo import api, SUPERUSER_ID
 
 muskathlon_task_sequence = {
     "task_criminal": 6,
@@ -13,4 +12,3 @@ muskathlon_task_sequence = {
 def migrate(env, version):
     for task_id, task_sequence in muskathlon_task_sequence.items():
         env.ref(f"muskathlon.{task_id}").sequence = task_sequence
-


### PR DESCRIPTION
- Changed the order of the tasks in the profile to match the email order.

## Task
Areas such as, Medical Survey, Child Protection Forms, Flights Details, etc, are all not visible within the MyCompassion/Muskathlon profiles of the participants. This means that if a new participant logs in now, they can't see that these things are needed and already fill it in - they currently need to wait until the email with the correct link comes.
Can we please make all of these parts already visible when a participant logs in?
