### PR TITLE
T1644 TOGETHER - sponsor a child link is not working when on focus

### DIFF
--- a/crowdfunding_compassion/static/src/js/website_widgets.js
+++ b/crowdfunding_compassion/static/src/js/website_widgets.js
@@ -29,6 +29,7 @@ odoo.define("crowdfunding_compassion.website_widgets", function (require) {
           else submit_button.attr("target", "");
         }
       });
+      donation_type_button.change();
     },
   });
 


### PR DESCRIPTION
The button was disconnected from logic as the option was checked using the HTML prop, not calling the JQuery on change callback.

Calling the on change callback directly ensures the action is coherent.

## Task
When clicking on a project on TOGETHER, the sponsor a child button is highlighted by default, but when clicking to "next step" the link is not working. 

