### PR TITLE
T1413 - Reorder website children

### DIFF
--- a/website_sponsorship/controllers/main.py
+++ b/website_sponsorship/controllers/main.py
@@ -37,7 +37,10 @@ class WebsiteChild(http.Controller):
         offset = (page - 1) * self._children_per_page
         domain = self._extend_search_domain(domain, kwargs)
         children = child_obj.search(
-            domain + website_domain, offset=offset, limit=self._children_per_page
+            domain + website_domain,
+            offset=offset,
+            limit=self._children_per_page,
+            order="unsponsored_since asc, create_date asc, completion_date asc",
         )
         if not children:
             return self.load_child(**kwargs)


### PR DESCRIPTION
Change the sort order of children based on `unsposored_since`. As it can be `NULL`, it falls back to `create_date` and then `completion_date`.

## Task
On the website "/children" page, the children are displayed ordered by local_id, showing then all children from the same country next to each other. It would be nicer to have a more "random" order, maybe based on "unsponsored_since" or lastname, something not really visible.