### PR TITLE
T1537 - my compassion data protection

### DIFF
--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -533,7 +533,7 @@ class MyAccountController(CustomerPortal):
         return request.render("my_compassion.my_donations_page_template", values)
 
     @route("/my/information", type="http", auth="user", website=True)
-    def my_information(self, form_id=None, **kw):
+    def my_information(self, form_id=None, privacy_policy=None, **kw):
         """
         The route to display the information about the partner
         :param form_id: the form that has been filled or None
@@ -547,6 +547,10 @@ class MyAccountController(CustomerPortal):
                 "partner": partner,
             }
         )
+
+        if privacy_policy == "accepted" and not partner.legal_agreement_date:
+            partner.legal_agreement_date = datetime.now()
+
         return request.render("my_compassion.my_information_page_template", values)
 
     @route("/my/download/<source>", type="http", auth="user", website=True)

--- a/my_compassion/i18n/de.po
+++ b/my_compassion/i18n/de.po
@@ -18,6 +18,11 @@ msgid "(view agreement)"
 msgstr "(Vereinbarung anzeigen)"
 
 #. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
+msgid "Sign the Agreement"
+msgstr "Unterschreiben"
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_gift_history
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_donations_gift_history
 msgid "<b>Amount</b>"

--- a/my_compassion/i18n/fr_CH.po
+++ b/my_compassion/i18n/fr_CH.po
@@ -18,6 +18,11 @@ msgid "(view agreement)"
 msgstr "(voir le contrat)"
 
 #. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
+msgid "Sign the Agreement"
+msgstr "Signer"
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_gift_history
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_donations_gift_history
 msgid "<b>Amount</b>"

--- a/my_compassion/templates/my_account_personal_info.xml
+++ b/my_compassion/templates/my_account_personal_info.xml
@@ -160,9 +160,9 @@
                                 </label>
                             </div>
                         <button
-              class="btn btn-primary w-100"
+              class="btn btn-primary w-100 mt-2"
               type="submit"
-            >Sign Data Protection and Legal Agreement</button>
+            >Sign the Agreement</button>
                     </form>
                 </div>
             </div>

--- a/my_compassion/templates/my_account_personal_info.xml
+++ b/my_compassion/templates/my_account_personal_info.xml
@@ -141,6 +141,29 @@
             />
                         <a href="/legal" target="_blank">(view agreement)</a>
                     </t>
+                    <form t-else="" enctype="application/x-www-form-urlencoded">
+                        <div class="form-check">
+                                <input
+                type="checkbox"
+                value="accepted"
+                id="privacy_policy"
+                name="privacy_policy"
+                class="s_website_form_input form-check-input"
+              />
+                                <label
+                class="form-check-label font-weight-normal"
+                for="privacy_policy"
+              >
+                                    <t
+                  t-call="website_legal_page.acceptance_full"
+                />
+                                </label>
+                            </div>
+                        <button
+              class="btn btn-primary w-100"
+              type="submit"
+            >Sign Data Protection and Legal Agreement</button>
+                    </form>
                 </div>
             </div>
         </template>


### PR DESCRIPTION
Add the possibility to sign the data privacy agreement inside the profile directly.

Clicking on the text next to the checkbox opens [https://compassion.ch/protection-des-donnees/](https://compassion.ch/protection-des-donnees/) in the user's language.

- Preview my compassion:
![image](https://github.com/user-attachments/assets/c7cc0aab-3ce9-4536-892b-6a02022c3c31)
- Preview muskathlon:
![image](https://github.com/user-attachments/assets/9134bd04-d9be-4c44-a19f-196e755e370b)
