### PR TITLE
T1441 - TOGETHER numbers

### DIFF
--- a/website_event_compassion/models/__init__.py
+++ b/website_event_compassion/models/__init__.py
@@ -20,4 +20,5 @@ from . import (
     recurring_contract,
     res_partner,
     sale_order_line,
+    res_lang
 )

--- a/website_event_compassion/models/__init__.py
+++ b/website_event_compassion/models/__init__.py
@@ -20,5 +20,5 @@ from . import (
     recurring_contract,
     res_partner,
     sale_order_line,
-    res_lang
+    res_lang,
 )

--- a/website_event_compassion/models/res_lang.py
+++ b/website_event_compassion/models/res_lang.py
@@ -10,13 +10,10 @@ from odoo import models
 
 
 class ResLang(models.Model):
-    _inherit = 'res.lang'
+    _inherit = "res.lang"
 
     def format(self, percent, value, grouping=False, monetary=False):
         res = super().format(percent, value, grouping, monetary)
-        if self.code == 'fr_CH':
+        if self.code == "fr_CH":
             res = res.replace("'", "&nbsp;")
         return res
-
-
-

--- a/website_event_compassion/models/res_lang.py
+++ b/website_event_compassion/models/res_lang.py
@@ -1,0 +1,22 @@
+##############################################################################
+#
+#    Copyright (C) 2024 Compassion CH (http://www.compassion.ch)
+#    @author: Clément Charmillot <ccharmillot@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import models
+
+
+class ResLang(models.Model):
+    _inherit = 'res.lang'
+
+    def format(self, percent, value, grouping=False, monetary=False):
+        res = super().format(percent, value, grouping, monetary)
+        if self.code == 'fr_CH':
+            res = res.replace("'", "&nbsp;")
+        return res
+
+
+

--- a/website_event_compassion/templates/event_page.xml
+++ b/website_event_compassion/templates/event_page.xml
@@ -54,9 +54,11 @@
             <t t-if="amount_inside">
                 <div t-attf-class="progress-amount #{ barometer_amount_class }">
                     <t
-            t-esc="'{:n}'.format(barometer.amount_raised or 0).replace(',', '\'')"
+            t-esc="barometer.amount_raised or 0"
+            t-options="{'widget': 'integer'}"
           />/<t
-            t-esc="'{:n}'.format(barometer.amount_objective or 0).replace(',', '\'')"
+            t-esc="barometer.amount_objective or 0"
+            t-options="{'widget': 'integer'}"
           />
                     <span
             t-field="barometer.sudo().company_id.currency_id.symbol"
@@ -67,9 +69,11 @@
         <t t-if="not amount_inside">
             <div t-attf-class="#{ barometer_amount_class }">
                 <t
-          t-esc="'{:n}'.format(barometer.amount_raised or 0).replace(',', '\'')"
+          t-esc="barometer.amount_raised or 0"
+          t-options="{'widget': 'integer'}"
         />/<t
-          t-esc="'{:n}'.format(barometer.amount_objective or 0).replace(',', '\'')"
+          t-esc="barometer.amount_objective or 0"
+          t-options="{'widget': 'integer'}"
         />
                 <span
           t-field="barometer.sudo().company_id.currency_id.symbol"


### PR DESCRIPTION
## Changes
- Change donation progress bar to use the user's language thousand separator.
- Overwrite the thousand separator for French on websites only. The separator used is `&nbsp`.

![image](https://github.com/user-attachments/assets/83e2d29a-034d-45ec-94f7-f9a238ac1f7b)

## Note
The screenshot in the task references Muskathlon and not TOGETHER.