### PR TITLE
T1567 wordpress import

### DIFF
--- a/website_sponsorship/models/res_partner_match.py
+++ b/website_sponsorship/models/res_partner_match.py
@@ -46,4 +46,3 @@ class PartnerMatch(models.AbstractModel):
             # No "firstname" or "lastname", the caller probably expected the initial
             # behavior of the parent with "name"
             return super()._match_name_and_zip(vals)
-

--- a/website_sponsorship/models/res_partner_match.py
+++ b/website_sponsorship/models/res_partner_match.py
@@ -16,23 +16,34 @@ class PartnerMatch(models.AbstractModel):
 
     def _match_email_and_name(self, vals):
         # Replace the rule with fuzzy search and using firstname and lastname
-        email = vals["email"].strip()
-        name = vals["firstname"] + " " + vals["lastname"]
-        return self.env["res.partner"].search(
-            [
-                ("name", "%", name),
-                ("email", "=ilike", email),
-            ],
-            limit=1,
-        )
+        try:
+            email = vals["email"].strip()
+            name = vals["firstname"] + " " + vals["lastname"]
+            return self.env["res.partner"].search(
+                [
+                    ("name", "%", name),
+                    ("email", "=ilike", email),
+                ],
+                limit=1,
+            )
+        except KeyError:
+            # No "firstname" or "lastname", the caller probably expected the initial
+            # behavior of the parent with "name"
+            return super()._match_email_and_name(vals)
 
     def _match_name_and_zip(self, vals):
         # Replace the rule for using firstname and lastname
-        name = vals["firstname"] + " " + vals["lastname"]
-        return self.env["res.partner"].search(
-            [
-                ("name", "ilike", name),
-                ("zip", "=", vals["zip"]),
-            ],
-            limit=1,
-        )
+        try:
+            name = vals["firstname"] + " " + vals["lastname"]
+            return self.env["res.partner"].search(
+                [
+                    ("name", "ilike", name),
+                    ("zip", "=", vals["zip"]),
+                ],
+                limit=1,
+            )
+        except KeyError:
+            # No "firstname" or "lastname", the caller probably expected the initial
+            # behavior of the parent with "name"
+            return super()._match_name_and_zip(vals)
+


### PR DESCRIPTION
### Note
Tested through shell by running
```py
env["account.move"].process_wp_confirmed_donation(donnation_infos={"email":"jean@mail.com", "name":"jean","street":"rue","zipcode":1234,"city":"City","language":"fr_CH","partner_ref":"???","child_id":100, "country":"Switzerland"})
```
Not tested through Wordpress, so it might not solve the issue if it doesn't expect name matching.
### Issue
`process_wp_confirmed_donation` receives only a `name` from Wordpress, but the filter expects `Lastname` and `Firstname` so no matching is made on the `name`. 

Other fix for same issue: CompassionCH/compassion-switzerland#1642