### PR TITLE
T1643 - Letter writing child selection

### DIFF
--- a/my_compassion/static/src/js/my_children.js
+++ b/my_compassion/static/src/js/my_children.js
@@ -4,7 +4,9 @@ const child_name = document.getElementsByClassName("child-name");
 const child_local_id = document.getElementsByClassName("child-local_id");
 
 // Change the href of the links to include the child_id
-const current_child_id = new URLSearchParams(window.location.search).get("child_id");
+const current_child_id = new URLSearchParams(window.location.search).get(
+    "child_id"
+);
 selector = document.querySelector('a[href="/my/letter"]');
 selector.href = selector.href + "?child_id=" + current_child_id;
 selector = document.querySelector('a[href="/my/children"]');

--- a/my_compassion/static/src/js/my_children.js
+++ b/my_compassion/static/src/js/my_children.js
@@ -5,7 +5,7 @@ const child_local_id = document.getElementsByClassName("child-local_id");
 
 // Change the href of the links to include the child_id
 const current_child_id = new URLSearchParams(window.location.search).get(
-    "child_id"
+  "child_id"
 );
 selector = document.querySelector('a[href="/my/letter"]');
 selector.href = selector.href + "?child_id=" + current_child_id;

--- a/my_compassion/static/src/js/my_children.js
+++ b/my_compassion/static/src/js/my_children.js
@@ -3,6 +3,13 @@ const child_images = document.getElementsByClassName("child-image");
 const child_name = document.getElementsByClassName("child-name");
 const child_local_id = document.getElementsByClassName("child-local_id");
 
+// Change the href of the links to include the child_id
+const current_child_id = new URLSearchParams(window.location.search).get("child_id");
+selector = document.querySelector('a[href="/my/letter"]');
+selector.href = selector.href + "?child_id=" + current_child_id;
+selector = document.querySelector('a[href="/my/children"]');
+selector.href = selector.href + "?child_id=" + current_child_id;
+
 function selectChild(selected_child_id, reload) {
   // Change url to display selected child
   const search_params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
When a sponsor supports multiple children, clicking on a specific child in MyCompassion and then selecting "Write a letter" from the menu does not persist the selected child. Instead, the system defaults to the first child in the list. This forces the sponsor to manually re-select the intended child to ensure the letter is directed correctly.