### PR TITLE
T1754 - Link to Together from Odoo not working

### DIFF
--- a/crowdfunding_compassion/models/crowdfunding_project.py
+++ b/crowdfunding_compassion/models/crowdfunding_project.py
@@ -523,3 +523,8 @@ For 42 francs a month, you're opening the way out of poverty for a child. Sponso
                 "crowdfunding_compassion/static/src/img/icn_children.png", "rb"
             ).read()
         )
+
+    def open_website_url(self):
+        res = super().open_website_url()
+        res["url"] = urlparse.urljoin(self.website_id._get_http_domain(), res["url"])
+        return res


### PR DESCRIPTION
Makes the `Go to Website` open the correct project on the website from the view [https://erp.compassion.ch/web?debug=1#action=1859&cids=1&menu_id=1893&model=crowdfunding.project&view_type=list](https://erp.compassion.ch/web?debug=1#action=1859&cids=1&menu_id=1893&model=crowdfunding.project&view_type=list).