### PR TITLE
T1808 - Sponsor cannot see terminated child before being notified of exit

### DIFF
--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -506,13 +506,11 @@ class MyAccountController(CustomerPortal):
 
         # Dict of groups mapped to their sponsorships, and total amount
         # {group: (<sponsorships recordset>, total_amount string), ...}
-        sponsorships_by_group = {
-            g: (
-                sponsorships.filtered(lambda s, g=g: s.group_id == g),
-                f"{int(sum(sponsorships.filtered(lambda s, g=g: s.group_id == g).mapped('total_amount'))):,d} {currency}",
-            )
-            for g in sponsorships.mapped("group_id")
-        }
+        sponsorships_by_group = {}
+        for g in sponsorships.mapped("group_id"):
+            filtered_sponsorships = sponsorships.filtered(lambda s: s.group_id == g)
+            total = int(sum(filtered_sponsorships.mapped('total_amount')))
+            sponsorships_by_group[g] = (filtered_sponsorships, f"{total:,d} {currency}")
 
         values = self._prepare_portal_layout_values()
         pager = request.website.pager(

--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -509,7 +509,7 @@ class MyAccountController(CustomerPortal):
         sponsorships_by_group = {}
         for g in sponsorships.mapped("group_id"):
             filtered_sponsorships = sponsorships.filtered(lambda s: s.group_id == g)
-            total = int(sum(filtered_sponsorships.mapped('total_amount')))
+            total = int(sum(filtered_sponsorships.mapped("total_amount")))
             sponsorships_by_group[g] = (filtered_sponsorships, f"{total:,d} {currency}")
 
         values = self._prepare_portal_layout_values()

--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -501,16 +501,16 @@ class MyAccountController(CustomerPortal):
             ]
         )
 
-        sponsorships = _get_sponsorships(partner, state="active")
-        currency = sponsorships.mapped("pricelist_id.currency_id")[:1].name
+        active_sponsorships = _get_sponsorships(partner, state="active")
+        currency = active_sponsorships.mapped("pricelist_id.currency_id")[:1].name
 
         # Dict of groups mapped to their sponsorships, and total amount
         # {group: (<sponsorships recordset>, total_amount string), ...}
         sponsorships_by_group = {}
-        for g in sponsorships.mapped("group_id"):
-            filtered_sponsorships = sponsorships.filtered(lambda s: s.group_id == g)
-            total = int(sum(filtered_sponsorships.mapped("total_amount")))
-            sponsorships_by_group[g] = (filtered_sponsorships, f"{total:,d} {currency}")
+        for g in active_sponsorships.mapped("group_id"):
+            sponsorships = active_sponsorships.filtered(lambda s, g=g: s.group_id == g)
+            total = int(sum(sponsorships.mapped("total_amount")))
+            sponsorships_by_group[g] = (sponsorships, f"{total:,d} {currency}")
 
         values = self._prepare_portal_layout_values()
         pager = request.website.pager(

--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -498,8 +498,15 @@ class MyAccountController(CustomerPortal):
             ]
         )
 
+        end_reason_child_depart = request.env.ref("sponsorship_compassion.end_reason_depart")
+
         sponsorships = partner.sponsorship_ids.filtered(
             lambda s: s.state in ["waiting", "active", "mandate"]
+            and partner == s.mapped("partner_id")
+            or
+            s.state == "terminated"
+            and s.can_write_letter
+            and s.end_reason_id == end_reason_child_depart
             and partner == s.mapped("partner_id")
         )
         currency = sponsorships.mapped("pricelist_id.currency_id")[:1].name
@@ -509,7 +516,7 @@ class MyAccountController(CustomerPortal):
         sponsorships_by_group = {
             g: (
                 sponsorships.filtered(lambda s, g=g: s.group_id == g),
-                f"{int(g.total_amount):,d} {currency}",
+                f"{int(sum(sponsorships.filtered(lambda s, g=g: s.group_id == g).mapped('total_amount'))):,d} {currency}",
             )
             for g in sponsorships.mapped("group_id")
         }


### PR DESCRIPTION
# Description
When a  sponsorship ends because of a child departure, until the sponsor is notified about the departure he should still be able to see the child in `MyCompassion`. It seems that the child is still shown in `/my/children`, however in `/my/donations` the child is not listed anymore so sponsors could figure out that the child has exited.

# Technical Aspects
* Refactored code to use same logic for fetching "active" sponsorships in both `/my/children` and `/my/donations`