### PR TITLE
T1835 Fix redirect loop for /child/<model('compassion.child'):child>

### DIFF
--- a/website_sponsorship/controllers/main.py
+++ b/website_sponsorship/controllers/main.py
@@ -93,7 +93,8 @@ class WebsiteChild(http.Controller):
 
     @http.route(
         [
-            "/child/<model('compassion.child'):child>/",
+            # [T1835] : Note: the route MUST be specified *without* a trailing "/" otherwise when a child with a given id does not exist, the 404 Not Found page is not displayed and instead we get an infinite redirect loop. The root cause is that specifying a path with a trailing "/" adds the "/" to the path, and then ir_http.py (https://github.com/odoo/odoo/blob/f2765d2cab5671a010404c36842bf1b4c4d6350b/addons/website/models/ir_http.py#L265) redirects to a version without the "/", creating the infinite loop.
+            "/child/<model('compassion.child'):child>",
         ],
         type="http",
         auth="public",

--- a/website_sponsorship/controllers/main.py
+++ b/website_sponsorship/controllers/main.py
@@ -93,7 +93,15 @@ class WebsiteChild(http.Controller):
 
     @http.route(
         [
-            # [T1835] : Note: the route MUST be specified *without* a trailing "/" otherwise when a child with a given id does not exist, the 404 Not Found page is not displayed and instead we get an infinite redirect loop. The root cause is that specifying a path with a trailing "/" adds the "/" to the path, and then ir_http.py (https://github.com/odoo/odoo/blob/f2765d2cab5671a010404c36842bf1b4c4d6350b/addons/website/models/ir_http.py#L265) redirects to a version without the "/", creating the infinite loop.
+            # [T1835] : Note: the route MUST be specified *without* a trailing
+            # "/" otherwise when a child with a given id does not exist, the 404
+            # Not Found page is not displayed and instead we get an infinite
+            # redirect loop. The root cause is that specifying a path with a
+            # trailing "/" adds the "/" to the path, and then ir_http.py
+            # (https://github.com/odoo/odoo/blob/
+            # f2765d2cab5671a010404c36842bf1b4c4d6350b/addons/website/models
+            # /ir_http.py#L265) redirects to a version without the "/", creating
+            # the infinite loop.
             "/child/<model('compassion.child'):child>",
         ],
         type="http",


### PR DESCRIPTION
This PR fixes the infinite redirect loop which appeared when a request to `/child/<model('compassion.child'):child>` was made with an invalid child id.
A related bug which is not fixed by this PR is that the `/children/random` route sometimes redirects to a child page of a child which does not exist. This can be fixed in a further PR.

To reproduce the bug locally and verify that this PR fixes the issue, I opened the browser to  `http://localhost:8069/child/gu099000031-2095`