### PR TITLE
T1903 Fix /children/random redirect producing 404 error

### DIFF
--- a/crowdfunding_compassion/models/crowdfunding_participant.py
+++ b/crowdfunding_compassion/models/crowdfunding_participant.py
@@ -68,7 +68,6 @@ class CrowdfundingParticipant(models.Model):
         "and to this partner.",
     )
 
-
     # kanban colors
     color_sponsorship = fields.Char(compute="_compute_color_sponsorship")
     color_product = fields.Char(compute="_compute_color_product")


### PR DESCRIPTION
The bug was caused by the fact that `/children/random` selected a child with `child.state` in `child._available_states()` but the `/child/<child_id>` endpoint only accepted children with `state == "N"` as valid. 
Thus, children with `state == "I"` were sometimes selected by `/children/random` and then produced a 404 when treated by `/child/<child_id>`.

The fix is to use the `_available_states()` method when checking for child availability instead of the hardcoded value `"N"`.

I also fixed `/child/<child_id>/sponsor` which was also affected.