### PR TITLE
[T1906] FEAT: Add new MyCompassion user signup logic using OCA module 2/2

### DIFF
--- a/my_compassion/__manifest__.py
+++ b/my_compassion/__manifest__.py
@@ -46,6 +46,8 @@
         "templates/signup.xml",
         "views/correspondence_template_view.xml",
         "views/partner_compassion_view.xml",
+        "data/signup_email_confirmation.xml",
+        "data/communication_config.xml",
     ],
     "depends": [
         "partner_communication_compassion",
@@ -54,6 +56,8 @@
         "website_sponsorship",
         "auth_signup",
         "website_crm_privacy_policy",  # OCA/website
+        "auth_signup_verify_email",  # OCA/server-auth
+        "queue_job",
     ],
     "demo": [],
     "installable": True,

--- a/my_compassion/data/communication_config.xml
+++ b/my_compassion/data/communication_config.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <data noupdate="0">
+        <record
+      id="user_account_confirmation"
+      model="partner.communication.config"
+    >
+            <field name="name">Signup Account Confirmation</field>
+            <field name="send_mode">digital</field>
+            <field
+        name="email_template_id"
+        ref="my_compassion.signup_confirmation_set_password_email"
+      />
+            <field name="print_if_not_email">False</field>
+            <field name="model_id" ref="base.model_res_partner" />
+        </record>
+
+    </data>
+</odoo>

--- a/my_compassion/data/signup_email_confirmation.xml
+++ b/my_compassion/data/signup_email_confirmation.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <!-- Email template for partner account confirmation -->
+        <record
+      id="signup_confirmation_set_password_email"
+      model="mail.template"
+    >
+            <field name="name">Compassion account confirmation</field>
+            <field
+        name="model_id"
+        ref="partner_communication.model_partner_communication_job"
+      />
+            <field
+        name="email_from"
+      >"${object.company_id.name | safe}"&lt;${(object.company_id.email or 'noreply@mycompassion.com') | safe}&gt;</field>
+            <field name="email_to">${object.partner_id.email|safe}</field>
+            <field name="use_default_to">True</field>
+            <field name="subject">Compassion account confirmation</field>
+
+            <field name="body_html" type="html">
+<div>
+    % set partner = object.partner_id
+</div>
+<p>
+    ${partner.salutation}
+</p>
+<p>
+    You have recently created an account on MyCompassion.
+</p>
+<p>
+    To activate your account, please click the button below and set a password (minimum eight characters).
+</p>
+<div style="margin:20px auto; text-align: center;">
+
+    <a
+            href="${object.partner_id.signup_url}"
+            style="padding: 12px 18px; font-size: 12px;
+     line-height: 18px; color: #FFFFFF; border-color:#0054A6; text-decoration: none; display: inline-block; margin-bottom: 0px; font-weight: 400; text-align: center; vertical-align: middle; cursor: pointer; white-space: nowrap; background-image: none; background-color: #0054A6; border: 1px solid #0054A6; border-radius:3px"
+            title=""
+          >
+        Activate my account
+    </a>
+</div>
+<p>
+    If you did not expect this, you can safely ignore this email.
+</p>
+<p>
+    Best regards
+</p>
+<p>
+     ${object.user_id.signature | safe}
+</p>
+            </field>
+
+            <field name="lang">${object.lang}</field>
+            <field name="auto_delete" eval="True" />
+        </record>
+    </data>
+</odoo>

--- a/my_compassion/i18n/de.po
+++ b/my_compassion/i18n/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Compassion Odoo 14\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-14 07:38+0000\n"
+"POT-Creation-Date: 2024-12-19 05:40+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -10,17 +10,111 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. module: my_compassion
+#: model:mail.template,body_html:my_compassion.signup_confirmation_set_password_email
+msgid ""
+"\n"
+"<div style=\"padding:0px;width:600px;margin:auto;background: #FFFFFF repeat "
+"top /100%;color:#777777\">\n"
+"    <table cellspacing=\"0\" cellpadding=\"0\" style=\"width:600px;border-"
+"collapse:collapse;background:inherit;color:inherit\">\n"
+"        <tbody><tr>\n"
+"            <td valign=\"center\" width=\"200\" style=\"padding:10px 10px "
+"10px 5px;font-size: 12px\">\n"
+"                <img src=\"/logo.png\" style=\"padding: 0px; margin: 0px; "
+"height: auto; width: 80px;\" alt=\"${user.company_id.name}\">\n"
+"            </td>\n"
+"        </tr></tbody>\n"
+"    </table>\n"
+"</div>\n"
+"<div style=\"padding:0px;width:600px;margin:auto;background: #FFFFFF repeat "
+"top /100%;color:#777777\">\n"
+"    <p>Dear ${object.partner_id.name},</p>\n"
+"    <p>You have recently created an account on Compassion.</p>\n"
+"    <p>To activate your account, please click the button below and set a "
+"password.</p>\n"
+"    <div style=\"text-align: center; margin-top: 16px;\">\n"
+"        <a href=\"${object.partner_id.signup_url}\" style=\"padding: 5px "
+"10px; font-size: 12px; line-height: 18px; color: #FFFFFF; border-color:"
+"#875A7B; text-decoration: none; display: inline-block; margin-bottom: 0px; "
+"font-weight: 400; text-align: center; vertical-align: middle; cursor: "
+"pointer; white-space: nowrap; background-image: none; background-color: "
+"#875A7B; border: 1px solid #875A7B; border-radius:3px\">Activate my account</"
+"a>\n"
+"    </div>\n"
+"    <p>If you do not expect this, you can safely ignore this email.</p>\n"
+"    <p>Best regards,</p>\n"
+"</div>\n"
+"<div style=\"padding:0px;width:600px;margin:auto; margin-top: 10px; "
+"background: #fff repeat top /100%;color:#777777\">\n"
+"    ${user.signature | safe}\n"
+"    <p style=\"font-size: 11px; margin-top: 10px;\">\n"
+"        <strong>Sent by ${user.company_id.name} using <a href=\"www.odoo."
+"com\" style=\"text-decoration:none; color: #875A7B;\">Odoo</a></strong>\n"
+"    </p>\n"
+"</div>\n"
+"            "
+msgstr ""
+"<div>\n"
+"    % set partner = object.partner_id\n"
+"    % set plural = partner.title.plural or partner.title.id == 29\n"
+"\n"
+"    % if plural:\n"
+"        % set Du = 'Ihr'\n"
+"        % set du = 'ihr'\n"
+"        % set dein = 'ihr'\n"
+"        % set hast = 'habt'\n"
+"        % set kannst = 'könnt'\n"
+"        % set Mein = 'Unser'\n"
+"    % else:\n"
+"        % set Du = 'Du'\n"
+"        % set du = 'du'\n"
+"        % set dein = 'dein'\n"
+"        % set hast = 'hast'\n"
+"        % set kannst = 'kannst'\n"
+"        % set Mein = 'Mein'\n"
+"    % endif\n"
+"</div>\n"
+"<p>\n"
+"    ${partner.salutation}\n"
+"</p>\n"
+"<p>\n"
+"    ${Du} ${hast} soeben ${dein} MyCompassion-Profil kreiert, gratuliere!\n"
+"</p>\n"
+"<p>\n"
+"    Damit wir ${dein} Profil aktiveren können, klicke bitte auf den Link und "
+"lege ${dein} Passwort fest (es muss\n"
+"    mindestens 8 Zeichen haben).\n"
+"</p>\n"
+"<div style=\"margin:20px auto; text-align: center;\">\n"
+"\n"
+"    <a href=\"${object.partner_id.signup_url}\" style=\"padding: 12px 18px; "
+"font-size: 12px;\n"
+"     line-height: 18px; color: #FFFFFF; border-color:#0054A6; text-"
+"decoration: none; display: inline-block; margin-bottom: 0px; font-weight: "
+"400; text-align: center; vertical-align: middle; cursor: pointer; white-"
+"space: nowrap; background-image: none; background-color: #0054A6; border: "
+"1px solid #0054A6; border-radius:3px\" title=\"\">\n"
+"        ${Mein} Profil freischalten\n"
+"    </a>\n"
+"</div>\n"
+"<p>\n"
+"    Falls ${dein} Profil bereits aufgeschaltet ist, ${kannst} ${du} diese "
+"Nachricht ignorieren.\n"
+"</p>\n"
+"<p>\n"
+"    Liebe Grüsse\n"
+"</p>\n"
+"<p>\n"
+"     ${object.user_id.signature | safe}\n"
+"</p>"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
 msgid "(view agreement)"
 msgstr "(Vereinbarung anzeigen)"
-
-#. module: my_compassion
-#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
-msgid "Sign the Agreement"
-msgstr "Unterschreiben"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_gift_history
@@ -190,6 +284,12 @@ msgid "Age"
 msgstr "Alter"
 
 #. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "An error occurred."
+msgstr "Es ist ein Fehler aufgetreten."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "Ask questions about his or her dreams for the future"
 msgstr "Frage nach den Zukunftsträumen"
@@ -203,6 +303,13 @@ msgstr "Geburtsdatum"
 #: model:ir.model.fields,field_description:my_compassion.field_correspondence_template__can_publish
 msgid "Can Publish"
 msgstr "Kann veröffentlichen"
+
+#. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "Cannot send email: the partner %s has no email address."
+msgstr ""
+"E-Mail kann nicht gesendet werden: Der Partner %s hat keine E-Mail-Adresse."
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
@@ -256,9 +363,22 @@ msgid "Common jobs"
 msgstr "Häufige Tätigkeiten"
 
 #. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "Communication configuration is missing."
+msgstr "Es fehlt eine Kommunikationskonfiguration."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
 msgid "Community"
 msgstr "Gemeinschaft"
+
+#. module: my_compassion
+#: model:mail.template,subject:my_compassion.signup_confirmation_set_password_email
+msgid "Compassion account confirmation"
+msgstr ""
+"Aktivierung ${'ihres' if object.partner_id.title.plural or object.partner_id."
+"title.id == 29 else 'deines'} MyCompassion-Profils"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
@@ -380,6 +500,12 @@ msgid "Father/representative's job"
 msgstr "Arbeit des Vaters/Betreuers"
 
 #. module: my_compassion
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move__gender__f
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move_line__gender__f
+msgid "Female"
+msgstr "Weiblich"
+
+#. module: my_compassion
 #: model:ir.model,name:my_compassion.model_compassion_project
 msgid "Frontline Church Partner"
 msgstr "Frontline-Kirchenpartner"
@@ -493,12 +619,12 @@ msgstr "Briefe von"
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_letters
 msgid "Letters history"
-msgstr "Briefe"
+msgstr "Briefe Geschichte"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
 msgid "Location"
-msgstr "Veranstaltungsort"
+msgstr "Lagerort"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.login_layout
@@ -509,6 +635,12 @@ msgstr "Anmeldung"
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "Make sure that any image you upload does not exceed 10Mb."
 msgstr "Bitte stelle sicher, dass dein Bild nicht 10 MB überschreitet."
+
+#. module: my_compassion
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move__gender__m
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move_line__gender__m
+msgid "Male"
+msgstr "Junge"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
@@ -664,9 +796,22 @@ msgid "Sign Child Protection Charter"
 msgstr "Unterschreiben"
 
 #. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
+msgid "Sign the Agreement"
+msgstr "Unterschreibe die Vereinbarung"
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
 msgid "Signup"
 msgstr "Registrieren"
+
+#. module: my_compassion
+#: model:partner.communication.config,name:my_compassion.user_account_confirmation
+#: model:utm.source,name:my_compassion.user_account_confirmation_utm_source
+msgid "Signup Account Confirmation"
+msgstr ""
+"Aktivierung ${'ihres' if object.partner_id.title.plural or object.partner_id."
+"title.id == 29 else 'deines'} MyCompassion-Profils"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
@@ -733,6 +878,28 @@ msgid ""
 msgstr "Leider ist die Bilddatei zu gross. Bitte komprimiere die Grösse mit"
 
 #. module: my_compassion
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid "The new password and its confirmation must be identical."
+msgstr "Das neue Passwort und seine Bestätigung müssen übereinstimmen."
+
+#. module: my_compassion
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid ""
+"The old password you provided is incorrect, your password was not changed."
+msgstr ""
+"Das alte Passwort, das sie eingegeben haben ist falsch, ihr Passwort wurde "
+"nicht geändert."
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
+msgid "The text of your letter is empty. Please add some text and try again."
+msgstr ""
+"Der Text deines Briefes ist leer. Bitte füge etwas Text hinzu und versuche "
+"es erneut."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "There are many easy-to-use solution to resize an image.<br/>for example"
 msgstr "Du kannst die Grösse des Bildes verkleinern, bspw. über "
@@ -763,14 +930,6 @@ msgstr ""
 "Bitte versuch es noch später und/oder restart dein Computer. <br/>\n"
 "Wenn der Fehler weiterhin besteht, kontaktiere uns auf info@compassion.ch, "
 "damit wir das Problem lösen können."
-
-#. module: my_compassion
-#: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
-msgid ""
-"The text of your letter is empty. Please add some text and try again."
-msgstr ""
-"Der Text Deines Briefes ist leer."
-"Bitte füge Text hinzu und versuche es erneut."
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_letters
@@ -883,6 +1042,19 @@ msgid "Writing guidelines"
 msgstr "Tipps zum Schreiben"
 
 #. module: my_compassion
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid "You cannot leave any password empty."
+msgstr "Sie können kein leeres Passwort setzen."
+
+#. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "You cannot perform this action on an archived user."
+msgstr ""
+"Du kannst diese Aktion nicht für einen archivierten Benutzer durchführen."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "Your e-mail address"
 msgstr "Deine E-Mail Adresse"
@@ -928,3 +1100,22 @@ msgstr "punchi.me"
 #: model_terms:ir.ui.view,arch_db:my_compassion.sponsor_a_child
 msgid "this link"
 msgstr "Klicke hier, um eine Patenschaft zu beginnen"
+
+#~ msgid "No sponsor found with this reference. Please try again."
+#~ msgstr ""
+#~ "Für diese Referenz wurde kein Sponsor gefunden. Bitte versuche es erneut."
+
+#~ msgid "Put any known reference here for matching with your account..."
+#~ msgstr ""
+#~ "Gib hier alle bekannten Referenzen ein, um sie mit deinem Konto "
+#~ "abzugleichen..."
+
+#~ msgid ""
+#~ "The email address you entered is not the same as the one in the system. "
+#~ "Please try again."
+#~ msgstr ""
+#~ "Die E-Mail-Adresse, die du eingegeben hast, stimmt nicht mit der im "
+#~ "System überein. Bitte versuche es erneut."
+
+#~ msgid "Your sponsor or child reference"
+#~ msgstr "Dein Pate oder dein Kind - Referenznummer"

--- a/my_compassion/i18n/fr_CH.po
+++ b/my_compassion/i18n/fr_CH.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Compassion Odoo 14\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-14 07:38+0000\n"
+"POT-Creation-Date: 2024-12-19 05:40+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -10,17 +10,92 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. module: my_compassion
+#: model:mail.template,body_html:my_compassion.signup_confirmation_set_password_email
+msgid ""
+"\n"
+"<div style=\"padding:0px;width:600px;margin:auto;background: #FFFFFF repeat "
+"top /100%;color:#777777\">\n"
+"    <table cellspacing=\"0\" cellpadding=\"0\" style=\"width:600px;border-"
+"collapse:collapse;background:inherit;color:inherit\">\n"
+"        <tbody><tr>\n"
+"            <td valign=\"center\" width=\"200\" style=\"padding:10px 10px "
+"10px 5px;font-size: 12px\">\n"
+"                <img src=\"/logo.png\" style=\"padding: 0px; margin: 0px; "
+"height: auto; width: 80px;\" alt=\"${user.company_id.name}\">\n"
+"            </td>\n"
+"        </tr></tbody>\n"
+"    </table>\n"
+"</div>\n"
+"<div style=\"padding:0px;width:600px;margin:auto;background: #FFFFFF repeat "
+"top /100%;color:#777777\">\n"
+"    <p>Dear ${object.partner_id.name},</p>\n"
+"    <p>You have recently created an account on Compassion.</p>\n"
+"    <p>To activate your account, please click the button below and set a "
+"password.</p>\n"
+"    <div style=\"text-align: center; margin-top: 16px;\">\n"
+"        <a href=\"${object.partner_id.signup_url}\" style=\"padding: 5px "
+"10px; font-size: 12px; line-height: 18px; color: #FFFFFF; border-color:"
+"#875A7B; text-decoration: none; display: inline-block; margin-bottom: 0px; "
+"font-weight: 400; text-align: center; vertical-align: middle; cursor: "
+"pointer; white-space: nowrap; background-image: none; background-color: "
+"#875A7B; border: 1px solid #875A7B; border-radius:3px\">Activate my account</"
+"a>\n"
+"    </div>\n"
+"    <p>If you do not expect this, you can safely ignore this email.</p>\n"
+"    <p>Best regards,</p>\n"
+"</div>\n"
+"<div style=\"padding:0px;width:600px;margin:auto; margin-top: 10px; "
+"background: #fff repeat top /100%;color:#777777\">\n"
+"    ${user.signature | safe}\n"
+"    <p style=\"font-size: 11px; margin-top: 10px;\">\n"
+"        <strong>Sent by ${user.company_id.name} using <a href=\"www.odoo."
+"com\" style=\"text-decoration:none; color: #875A7B;\">Odoo</a></strong>\n"
+"    </p>\n"
+"</div>\n"
+"            "
+msgstr ""
+"<div>\n"
+"    % set partner = object.partner_id\n"
+"</div>\n"
+"<p>\n"
+"    ${partner.salutation}\n"
+"</p>\n"
+"<p>\n"
+"    Vous venez de créer votre profil MyCompassion, félicitations !\n"
+"</p>\n"
+"<p>\n"
+"    Pour activer votre profil, veuillez cliquer sur le lien et choisir votre "
+"mot de passe (8 caractères minimum).\n"
+"</p>\n"
+"<div style=\"margin:20px auto; text-align: center;\">\n"
+"\n"
+"    <a href=\"${object.partner_id.signup_url}\" style=\"padding: 12px 18px; "
+"font-size: 12px;\n"
+"     line-height: 18px; color: #FFFFFF; border-color:#0054A6; text-"
+"decoration: none; display: inline-block; margin-bottom: 0px; font-weight: "
+"400; text-align: center; vertical-align: middle; cursor: pointer; white-"
+"space: nowrap; background-image: none; background-color: #0054A6; border: "
+"1px solid #0054A6; border-radius:3px\" title=\"\">\n"
+"        Activer mon profil\n"
+"    </a>\n"
+"</div>\n"
+"<p>\n"
+"    Si vous avez déjà activé votre profil, vous pouvez ignorer ce message.\n"
+"</p>\n"
+"<p>\n"
+"    Meilleures salutations\n"
+"</p>\n"
+"<p>\n"
+"     ${object.user_id.signature | safe}\n"
+"</p>"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
 msgid "(view agreement)"
 msgstr "(voir le contrat)"
-
-#. module: my_compassion
-#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
-msgid "Sign the Agreement"
-msgstr "Signer"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_gift_history
@@ -191,6 +266,12 @@ msgid "Age"
 msgstr "Âge"
 
 #. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "An error occurred."
+msgstr "Une erreur est survenue."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "Ask questions about his or her dreams for the future"
 msgstr "Posez des questions sur les rêves d'avenir de votre filleul"
@@ -204,6 +285,12 @@ msgstr "Date de naissance"
 #: model:ir.model.fields,field_description:my_compassion.field_correspondence_template__can_publish
 msgid "Can Publish"
 msgstr "Peut publier"
+
+#. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "Cannot send email: the partner %s has no email address."
+msgstr "Échec d'envoi: le partenaire %s n'a pas d'e-mail."
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
@@ -257,9 +344,20 @@ msgid "Common jobs"
 msgstr "Emplois habituels"
 
 #. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "Communication configuration is missing."
+msgstr "Le type de communication est manquant."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
 msgid "Community"
 msgstr "Communauté"
+
+#. module: my_compassion
+#: model:mail.template,subject:my_compassion.signup_confirmation_set_password_email
+msgid "Compassion account confirmation"
+msgstr "Activation de votre profil MyCompassion"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
@@ -382,6 +480,12 @@ msgid "Father/representative's job"
 msgstr "Travail du père / représentant légal"
 
 #. module: my_compassion
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move__gender__f
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move_line__gender__f
+msgid "Female"
+msgstr "Fille"
+
+#. module: my_compassion
 #: model:ir.model,name:my_compassion.model_compassion_project
 msgid "Frontline Church Partner"
 msgstr "Église partenaire"
@@ -432,7 +536,7 @@ msgstr "J'aimerais écrire à :"
 #: model:ir.model.fields,field_description:my_compassion.field_res_partner__id
 #: model:ir.model.fields,field_description:my_compassion.field_res_users__id
 msgid "ID"
-msgstr "ID"
+msgstr "Identifiant"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
@@ -482,7 +586,7 @@ msgstr "Langue"
 #: model:ir.model.fields,field_description:my_compassion.field_res_partner____last_update
 #: model:ir.model.fields,field_description:my_compassion.field_res_users____last_update
 msgid "Last Modified on"
-msgstr "Dernière Modification le"
+msgstr "Dernière modification le"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
@@ -514,6 +618,12 @@ msgstr "Connexion"
 msgid "Make sure that any image you upload does not exceed 10Mb."
 msgstr ""
 "Assurez-vous que toute image que vous téléchargez ne dépasse pas 10 Mo."
+
+#. module: my_compassion
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move__gender__m
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move_line__gender__m
+msgid "Male"
+msgstr "Garçon"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
@@ -669,9 +779,20 @@ msgid "Sign Child Protection Charter"
 msgstr "Signer la charte"
 
 #. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
+msgid "Sign the Agreement"
+msgstr "Signer"
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
 msgid "Signup"
 msgstr "Créer un compte"
+
+#. module: my_compassion
+#: model:partner.communication.config,name:my_compassion.user_account_confirmation
+#: model:utm.source,name:my_compassion.user_account_confirmation_utm_source
+msgid "Signup Account Confirmation"
+msgstr "Activation de votre profil MyCompassion"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
@@ -739,6 +860,27 @@ msgstr ""
 "toujours envoyer cette image si vous la redimensionnez d’abord avec"
 
 #. module: my_compassion
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid "The new password and its confirmation must be identical."
+msgstr "Le nouveau mot de passe et sa confirmation doivent être identiques."
+
+#. module: my_compassion
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid ""
+"The old password you provided is incorrect, your password was not changed."
+msgstr ""
+"L'ancien mot de passe que vous avez fourni est incorrect : votre mot de "
+"passe n'a pas été modifié."
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
+msgid "The text of your letter is empty. Please add some text and try again."
+msgstr ""
+"Le texte de votre lettre est vide. Veuillez ajouter du texte et réessayer."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "There are many easy-to-use solution to resize an image.<br/>for example"
 msgstr ""
@@ -772,13 +914,6 @@ msgstr ""
 "ordinateur.<br/>\n"
 "Si l'erreur persiste, Merci de nous contacter à info@compassion.ch pour nous "
 "signaler le problème."
-
-#. module: my_compassion
-#: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
-msgid ""
-"The text of your letter is empty. Please add some text and try again."
-msgstr ""
-"Le texte de votre lettre est vide. Veuillez ajouter du texte et réessayer."
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_letters
@@ -891,6 +1026,18 @@ msgid "Writing guidelines"
 msgstr "Conseils de rédaction"
 
 #. module: my_compassion
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid "You cannot leave any password empty."
+msgstr "Vous ne pouvez pas laisser un mot de passe vide"
+
+#. module: my_compassion
+#: code:addons/my_compassion/models/res_user.py:0
+#, python-format
+msgid "You cannot perform this action on an archived user."
+msgstr "Impossible d'effectuer cette action sur un utilisateur inactif."
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "Your e-mail address"
 msgstr "Votre adresse e-mail"
@@ -935,3 +1082,22 @@ msgstr "punchi.me"
 #: model_terms:ir.ui.view,arch_db:my_compassion.sponsor_a_child
 msgid "this link"
 msgstr "en cliquant ici"
+
+#~ msgid "No sponsor found with this reference. Please try again."
+#~ msgstr ""
+#~ "Aucun parrain n'a été trouvé pour cette référence. Veuillez réessayer."
+
+#~ msgid "Put any known reference here for matching with your account..."
+#~ msgstr ""
+#~ "Mettez ici toute référence connue pour qu'elle corresponde à votre "
+#~ "compte..."
+
+#~ msgid ""
+#~ "The email address you entered is not the same as the one in the system. "
+#~ "Please try again."
+#~ msgstr ""
+#~ "L'adresse électronique que vous avez saisie n'est pas la même que celle "
+#~ "qui figure dans le système. Veuillez réessayer."
+
+#~ msgid "Your sponsor or child reference"
+#~ msgstr "Votre référence parrain ou enfant"

--- a/my_compassion/i18n/it.po
+++ b/my_compassion/i18n/it.po
@@ -1,16 +1,19 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* my_compassion
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Compassion Odoo 14\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-14 07:38+0000\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2024-12-19 05:39+0000\n"
+"PO-Revision-Date: 2024-12-19 05:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
@@ -60,17 +63,15 @@ msgstr "<b>Contributo mensile</b>"
 #: model_terms:ir.ui.view,arch_db:my_compassion.sponsor_a_child
 msgid ""
 "<br/><br/><br/>\n"
-"                    You do not support any child yet. You can start a "
-"sponsorship by following"
+"                    You do not support any child yet. You can start a sponsorship by following"
 msgstr ""
 "<br/><br/><br/>\n"
-"                    Non sostieni ancora nessun bambino. Puoi iniziare un "
-"sostegno seguendo i seguenti passaggi"
+"                    Non sostieni ancora nessun bambino. Puoi iniziare un sostegno seguendo i seguenti passaggi"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "<span aria-hidden=\"true\">&amp;times;</span>"
-msgstr "<span aria-hidden=\"true\">&amp;times;</span>"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
@@ -124,8 +125,8 @@ msgstr "<span>Scarica tutte le immagini di </span>"
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_letters
 msgid "<span>Download correspondence from all my sponsored children</span>"
 msgstr ""
-"<span>Scaricare la corrispondenza di tutti i miei bambini sponsorizzati</"
-"span>"
+"<span>Scaricare la corrispondenza di tutti i miei bambini "
+"sponsorizzati</span>"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_pictures
@@ -175,7 +176,7 @@ msgstr "<span>Sponsorizzazioni terminate</span>"
 #. module: my_compassion
 #: model:ir.model,name:my_compassion.model_recurring_contract_group
 msgid "A group of contracts"
-msgstr "Un gruppo di contratti"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
@@ -215,7 +216,7 @@ msgstr "Immagine del bambino"
 #. module: my_compassion
 #: model:ir.model,name:my_compassion.model_compassion_child_pictures
 msgid "Child picture"
-msgstr "Immagine del bambino"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
@@ -267,8 +268,8 @@ msgstr "Centro di compassione"
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
 msgid ""
 "Compassion is also serious about the protection of your data. All your "
-"information is kept private and only used internally. You can sign or review "
-"our data protection policy from here."
+"information is kept private and only used internally. You can sign or review"
+" our data protection policy from here."
 msgstr ""
 "Compassion si preoccupa anche di proteggere i tuoi dati. Tutte le tue "
 "informazioni vengono mantenute private e utilizzate solo internamente. Puoi "
@@ -280,8 +281,8 @@ msgid ""
 "Compassion knows that children living in extreme poverty are vulnerable. We "
 "put their protection as our number one priority."
 msgstr ""
-"Compassion sa che i bambini che vivono in condizioni di estrema povertà sono "
-"vulnerabili. La loro protezione è la nostra priorità numero uno."
+"Compassion sa che i bambini che vivono in condizioni di estrema povertà sono"
+" vulnerabili. La loro protezione è la nostra priorità numero uno."
 
 #. module: my_compassion
 #: model:ir.model,name:my_compassion.model_res_partner
@@ -301,7 +302,7 @@ msgstr "Coordinate"
 #. module: my_compassion
 #: model:ir.model,name:my_compassion.model_correspondence_template
 msgid "Correspondence template"
-msgstr "Modello di corrispondenza"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
@@ -311,7 +312,7 @@ msgstr "Paese"
 #. module: my_compassion
 #: model:ir.model.fields,field_description:my_compassion.field_res_users__created_with_magic_link
 msgid "Created With Magic Link"
-msgstr "Creato con Magic Link"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
@@ -328,7 +329,7 @@ msgstr "Protezione dei dati e accordo legale"
 #: model:ir.model.fields,field_description:my_compassion.field_res_partner__display_name
 #: model:ir.model.fields,field_description:my_compassion.field_res_users__display_name
 msgid "Display Name"
-msgstr "Nome visualizzato"
+msgstr "Visualizza Nome"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
@@ -354,7 +355,7 @@ msgstr "Livello di istruzione"
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
 msgid "Email"
-msgstr "Email"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
@@ -377,9 +378,14 @@ msgid "Father/representative's job"
 msgstr "Lavoro del padre/rappresentante"
 
 #. module: my_compassion
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move_line__gender__f
+msgid "Female"
+msgstr ""
+
+#. module: my_compassion
 #: model:ir.model,name:my_compassion.model_compassion_project
 msgid "Frontline Church Partner"
-msgstr "Chiesa partner in prima linea"
+msgstr ""
 
 #. module: my_compassion
 #: model:ir.model.fields,field_description:my_compassion.field_account_bank_statement_line__gender
@@ -427,7 +433,7 @@ msgstr "Voglio scrivere a:"
 #: model:ir.model.fields,field_description:my_compassion.field_res_partner__id
 #: model:ir.model.fields,field_description:my_compassion.field_res_users__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
@@ -455,12 +461,12 @@ msgstr "Viene pubblicato"
 #. module: my_compassion
 #: model:ir.model,name:my_compassion.model_account_move
 msgid "Journal Entry"
-msgstr "Diario di bordo"
+msgstr ""
 
 #. module: my_compassion
 #: model:ir.model,name:my_compassion.model_account_move_line
 msgid "Journal Item"
-msgstr "Articolo di giornale"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
@@ -477,7 +483,7 @@ msgstr "Lingua"
 #: model:ir.model.fields,field_description:my_compassion.field_res_partner____last_update
 #: model:ir.model.fields,field_description:my_compassion.field_res_users____last_update
 msgid "Last Modified on"
-msgstr "Ultima modifica su"
+msgstr "Data di ultima modifica"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
@@ -510,9 +516,14 @@ msgid "Make sure that any image you upload does not exceed 10Mb."
 msgstr "Assicurati che le immagini caricate non superino i 10Mb."
 
 #. module: my_compassion
+#: model:ir.model.fields.selection,name:my_compassion.selection__account_move_line__gender__m
+msgid "Male"
+msgstr ""
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_personal
 msgid "Mobile"
-msgstr "Mobile"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_info
@@ -582,6 +593,7 @@ msgid "Need help?"
 msgstr "Hai bisogno di aiuto?"
 
 #. module: my_compassion
+#: code:addons/addons-compassion-switzerland/compassion-website/my_compassion/controllers/my_account.py:0
 #: code:addons/my_compassion/controllers/my_account.py:0
 #, python-format
 msgid "No text provided for the letter."
@@ -663,6 +675,11 @@ msgid "Sign Child Protection Charter"
 msgstr "Firma la Carta per la protezione dell'infanzia"
 
 #. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
+msgid "Sign the Agreement"
+msgstr ""
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.register_layout
 msgid "Signup"
 msgstr "Iscriviti"
@@ -673,12 +690,14 @@ msgid "Signup now"
 msgstr "Iscriviti ora"
 
 #. module: my_compassion
+#: code:addons/addons-compassion-switzerland/compassion-website/my_compassion/models/move.py:0
 #: code:addons/my_compassion/models/move.py:0
 #, python-format
 msgid "Sponsorship"
-msgstr "Sostegno"
+msgstr ""
 
 #. module: my_compassion
+#: code:addons/addons-compassion-switzerland/compassion-website/my_compassion/models/move.py:0
 #: code:addons/my_compassion/models/move.py:0
 #, python-format
 msgid "Sponsorship gift"
@@ -700,13 +719,13 @@ msgid ""
 "Tell simple stories about your life, your village or town, your hobbies, "
 "your work and your family"
 msgstr ""
-"Racconta storie semplici sulla tua vita, sul tuo villaggio o città, sui tuoi "
-"hobby, sul tuo lavoro e sulla tua famiglia."
+"Racconta storie semplici sulla tua vita, sul tuo villaggio o città, sui tuoi"
+" hobby, sul tuo lavoro e sulla tua famiglia."
 
 #. module: my_compassion
 #: model:ir.model.fields,field_description:my_compassion.field_correspondence_template__template_image_url
 msgid "Template Image Url"
-msgstr "Template Immagine Url"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_templates
@@ -733,11 +752,34 @@ msgstr ""
 "inviare l'immagine se prima la ridimensioni con"
 
 #. module: my_compassion
-#: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
-msgid "There are many easy-to-use solution to resize an image.<br/>for example"
+#: code:addons/addons-compassion-switzerland/compassion-website/my_compassion/controllers/my_account.py:0
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid "The new password and its confirmation must be identical."
 msgstr ""
-"Ci sono molte soluzioni facili da usare per ridimensionare un'immagine.<br/"
-">per esempio"
+
+#. module: my_compassion
+#: code:addons/addons-compassion-switzerland/compassion-website/my_compassion/controllers/my_account.py:0
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid ""
+"The old password you provided is incorrect, your password was not changed."
+msgstr ""
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
+msgid "The text of your letter is empty. Please add some text and try again."
+msgstr ""
+"Il testo della tua lettera è vuoto. Si prega di aggiungere del testo e "
+"riprovare."
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
+msgid ""
+"There are many easy-to-use solution to resize an image.<br/>for example"
+msgstr ""
+"Ci sono molte soluzioni facili da usare per ridimensionare "
+"un'immagine.<br/>per esempio"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
@@ -746,32 +788,20 @@ msgid ""
 "text and that your attachments are valid. Please contact us at "
 "info@compassion.ch if you experience unexpected behaviours."
 msgstr ""
-"Si è verificato un errore durante il rendering dell'anteprima. Assicurati di "
-"aver inserito del testo e che gli allegati siano validi. Se riscontri "
+"Si è verificato un errore durante il rendering dell'anteprima. Assicurati di"
+" aver inserito del testo e che gli allegati siano validi. Se riscontri "
 "comportamenti inaspettati, contattaci all'indirizzo info@compassion.ch."
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
 msgid ""
 "There was an error while submitting your letter.<br/>\n"
-"                Please try again later and/or try to reboot your computer."
-"<br/>\n"
-"                If the error still persist, copy your text to make sure you "
-"won't lose it and contact us at info@compassion.ch for signaling the issue."
+"                Please try again later and/or try to reboot your computer.<br/>\n"
+"                If the error still persist, copy your text to make sure you won't lose it and contact us at info@compassion.ch for signaling the issue."
 msgstr ""
 "Si è verificato un errore durante l'invio della lettera.\n"
-"                Ti preghiamo di riprovare più tardi e/o di provare a "
-"riavviare il computer.<br/>\n"
-"                Se l'errore persiste, copia il testo per assicurarti di non "
-"perderlo e contattaci all'indirizzo info@compassion.ch per segnalare il "
-"problema."
-
-#. module: my_compassion
-#: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
-msgid ""
-"The text of your letter is empty. Please add some text and try again."
-msgstr ""
-"Il testo della tua lettera è vuoto. Si prega di aggiungere del testo e riprovare."
+"                Ti preghiamo di riprovare più tardi e/o di provare a riavviare il computer.<br/>\n"
+"                Se l'errore persiste, copia il testo per assicurarti di non perderlo e contattaci all'indirizzo info@compassion.ch per segnalare il problema."
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_children_letters
@@ -817,7 +847,7 @@ msgstr "Guarda la mia lettera"
 #. module: my_compassion
 #: model:ir.model.fields,field_description:my_compassion.field_correspondence_template__website_published
 msgid "Visible on current website"
-msgstr "Visibile sul sito web attuale"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my_information_privacy_data
@@ -884,6 +914,13 @@ msgid "Writing guidelines"
 msgstr "Linee guida per la scrittura"
 
 #. module: my_compassion
+#: code:addons/addons-compassion-switzerland/compassion-website/my_compassion/controllers/my_account.py:0
+#: code:addons/my_compassion/controllers/my_account.py:0
+#, python-format
+msgid "You cannot leave any password empty."
+msgstr ""
+
+#. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "Your e-mail address"
 msgstr "Il tuo indirizzo e-mail"
@@ -925,7 +962,7 @@ msgstr "donazione"
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_actions
 #: model_terms:ir.ui.view,arch_db:my_compassion.letter_text_content
 msgid "punchi.me"
-msgstr "punchi.me"
+msgstr ""
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.sponsor_a_child

--- a/my_compassion/models/res_user.py
+++ b/my_compassion/models/res_user.py
@@ -8,7 +8,10 @@
 ##############################################################################
 import logging
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+from odoo.addons.auth_signup.models.res_partner import now
 
 _logger = logging.getLogger(__name__)
 
@@ -31,3 +34,151 @@ class ResUsers(models.Model):
             if len(users) != 1:
                 raise
             return users.action_reset_password()
+
+    def _find_and_replace_partner_async(self, user_id, email):
+        """Asynchronously find an existing partner by email and link it to the user,
+        removing the default partner (created in the signup) if necessary.
+        """
+
+        self = self.sudo()
+        user = self.env["res.users"].browse(user_id)
+
+        # Ensure the user exists and is valid
+        if not user.exists():
+            _logger.error("User with ID %s no longer exists. Task aborted.", user_id)
+            return
+
+        old_partner = user.partner_id
+        selected_partner = old_partner  # By default, keep the current partner
+
+        # Check for other partners with the same email
+        partners = self.env["res.partner"].search(
+            [("email", "=", email), ("id", "!=", old_partner.id)]
+        )
+
+        if partners:
+            # Select the best existing partner
+            selected_partner = partners.sorted(
+                key=lambda partner: (
+                    partner.number_sponsorships,
+                    partner.write_date or partner.create_date,
+                ),
+                reverse=True,
+            )[0]
+            user.write({"partner_id": selected_partner.id})
+            _logger.info(
+                "User %s linked to existing partner %s asynchronously.",
+                user.login,
+                selected_partner.name,
+            )
+            selected_partner.signup_type = old_partner.signup_type
+            selected_partner.signup_token = old_partner.signup_token
+            selected_partner.signup_expiration = old_partner.signup_expiration
+            selected_partner.signup_url = old_partner.signup_url
+            old_partner.unlink()
+            _logger.info("Partner deleted.")
+
+            _logger.info(
+                "User %s linked to existing partner %s asynchronously.",
+                user.login,
+                selected_partner.name,
+            )
+        else:
+            # No better partner found
+            _logger.info("No other partner found for user %s.", user.login)
+
+        self.flush()
+
+    @api.model
+    def signup(self, values, token=None):
+        """Override the signup process to include business
+        logic for linking existing partners.
+        After creating a new user and partner, ensure that users
+        are properly linked to existing partners based on their email.
+        """
+        # This is not a valid user field but is used for legal agreements
+        values.pop("privacy_policy", None)
+
+        # Call the superclass's signup method
+        dbname, login, password = super().signup(values, token)
+
+        if not token:
+            email = values.get("email") or values.get("login")
+
+            # Retrieve the newly created user
+            user = self.search([("login", "=", login)], limit=1)
+            if not user:
+                _logger.error(
+                    "Signup failed: No user found with login '%s' after signup.", login
+                )
+                return dbname, login, password  # Or handle as appropriate
+
+            # Ensure changes are flushed and committed before scheduling the job
+            self.flush()
+
+            # Queue the task to find or replace the partner
+            self.with_delay()._find_and_replace_partner_async(user.id, email)
+            _logger.info(
+                "Async task to find and replace partner for user %s queued.",
+                user.login,
+            )
+
+        return dbname, login, password
+
+    def action_reset_password(self):
+        """Create signup token for each user and send their signup URL
+        by creating a communication job.
+        Called only when user is created. Not when reseting password
+        """
+        if self.env.context.get("install_mode", False):
+            return
+        if self.filtered(lambda user: not user.active):
+            raise UserError(_("You cannot perform this action on an archived user."))
+
+        # Prepare reset password signup
+        create_mode = bool(self.env.context.get("create_user"))
+        expiration = False if create_mode else now(days=+1)
+        self.mapped("partner_id").signup_prepare(
+            signup_type="reset", expiration=expiration
+        )
+
+        # Retrieve the communication config
+        comm_config = self.env.ref(
+            "my_compassion.user_account_confirmation", raise_if_not_found=False
+        )
+        if not comm_config:
+            raise UserError(_("Communication configuration is missing."))
+
+        for user in self:
+            partner = user.partner_id
+            if not partner.email:
+                raise UserError(
+                    _(
+                        "Cannot send email: the partner %s has no email address.",
+                        partner.name,
+                    )
+                )
+
+            try:
+                # Create the job and send the email
+                self.env["partner.communication.job"].create(
+                    {
+                        "partner_id": partner.id,
+                        "config_id": comm_config.id,
+                        "auto_send": True,
+                    }
+                )
+
+            except Exception as e:
+                _logger.error(
+                    "Failed to send account confirmation email for user %s: %s",
+                    user.login,
+                    e,
+                )
+                raise UserError(_("An error occurred.")) from e
+
+            _logger.info(
+                "Password reset job created for user <%s> to <%s>",
+                user.login,
+                partner.email,
+            )


### PR DESCRIPTION
Adding the new signup for MyCompassion.

This solution use the OCA module "auth_signup_verify_email" from https://github.com/OCA/server-auth/tree/14.0

The two main objectives were:

- Sending a confirmation email to the newly signed-up user to activate their account.
- Linking the new user to a potentially existing partner based on the email address provided during signup.

The partner is selected based on the number of sponsorships, and in case of a tie, the most recently updated partner is chosen.

Partner linking is handled asynchronously. By default, a new partner is created as usual. If an existing partner is found, the res_user and res_partner data are updated to establish the link."

