### PR TITLE
T2038 - Fix non jpg image attachment bug

### DIFF
--- a/my_compassion/static/src/js/write_a_letter.js
+++ b/my_compassion/static/src/js/write_a_letter.js
@@ -159,8 +159,8 @@ function displayAlert(id) {
 }
 
 /**
- * 
- * @param {File} image 
+ *
+ * @param {File} image
  * @returns True iff the mimetype of the given file is image/jpeg
  */
 function isJPEGImage(image) {
@@ -192,8 +192,9 @@ function displayImages() {
             compressReader.onload = function (t_event) {
               // [T2038] the new image name is necessary because the backend uses the
               // extension as a hint to detect the mimetype.
-              const new_name = isJPEGImage(original_image) ? 
-                original_image.name : original_image.name + ".jpg";
+              const new_name = isJPEGImage(original_image)
+                ? original_image.name
+                : original_image.name + ".jpg";
               const final_data = {
                 name: new_name,
                 data: t_event.target.result.split(",")[1],

--- a/my_compassion/static/src/js/write_a_letter.js
+++ b/my_compassion/static/src/js/write_a_letter.js
@@ -159,6 +159,15 @@ function displayAlert(id) {
 }
 
 /**
+ * 
+ * @param {File} image 
+ * @returns True iff the mimetype of the given file is image/jpeg
+ */
+function isJPEGImage(image) {
+  return image.type.valueOf() === "image/jpeg";
+}
+
+/**
  * Display the images contained in new_images inside the HTML page
  */
 function displayImages() {
@@ -176,13 +185,17 @@ function displayImages() {
       image.onload = function (event) {
         if (
           original_image.size > resize_limit ||
-          original_image.type.valueOf() !== "image/jpeg"
+          !isJPEGImage(original_image)
         ) {
           compressImage(image).then((blob) => {
             const compressReader = new FileReader();
             compressReader.onload = function (t_event) {
+              // [T2038] the new image name is necessary because the backend uses the
+              // extension as a hint to detect the mimetype.
+              const new_name = isJPEGImage(original_image) ? 
+                original_image.name : original_image.name + ".jpg";
               const final_data = {
-                name: original_image.name,
+                name: new_name,
                 data: t_event.target.result.split(",")[1],
               };
               images_comp = images_comp.concat(final_data);


### PR DESCRIPTION
Before this fix, when adding a png image attachment to a letter, the sending would fail.
This was caused by the fact that the backend only accepts jpg images and incorrectly detected converted png -> jpg images as png.
The fix adds a ".jpg" extension to converted images so that the backend recognizes them as jpeg.