### PR TITLE
[T2165] : Fixed pictures fullshot for sponsorships in MyCompassion

### DIFF
--- a/my_compassion/templates/my_account_my_children.xml
+++ b/my_compassion/templates/my_account_my_children.xml
@@ -432,7 +432,7 @@
                 >
                                     <img
                     class="mx-auto"
-                    t-attf-src='https://erp.compassion.ch/web/image/compassion.child.pictures/{{picture.id}}/fullshot/'
+                    t-attf-src='/web/image/compassion.child.pictures/{{picture.id}}/fullshot/'
                     style="max-width: 120px; width: 100%; height: auto;"
                   />
                                     <div class="card-body pt-2">


### PR DESCRIPTION
the link for the pictures section was hard coded and wrong (and we kinda also fixed the security rule for child pictures which is working better now)

Changes should already be in production.