### PR TITLE
[T2114] : Fixed event registration data leak

### DIFF
--- a/website_event_compassion/models/event_registration.py
+++ b/website_event_compassion/models/event_registration.py
@@ -408,6 +408,7 @@ class EventRegistration(models.Model):
                         "res_id": registration.id,
                         "datas": passport,
                         "name": name,
+                        "public": False,
                     }
                 )
             else:


### PR DESCRIPTION
the ir.attachment object will now correctly be created : field "public" being now "false" prevents a leak of the passport data throughout a link
