### PR TITLE
[T2333] New page displayed complete informations

### DIFF
--- a/website_sponsorship/controllers/main.py
+++ b/website_sponsorship/controllers/main.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from random import randint
 
-from werkzeug.exceptions import BadRequest, Gone, NotFound
+from werkzeug.exceptions import Gone, NotFound
 
 from odoo import http
 from odoo.http import request
@@ -171,8 +171,19 @@ class WebsiteChild(http.Controller):
             .sudo()
             .search([("child_id", "=", child_id), ("state", "=", "draft")], limit=1)
         )
+        is_done = not contract.is_first_sponsorship
         if not contract:
-            raise BadRequest()
+            contract = (
+                request.env["recurring.contract"]
+                .sudo()
+                .search([("child_id", "=", child_id)], limit=1)
+            )
+            if not contract:
+                raise NotFound()
+            # If the contract is not in draft state, we assume it has been
+            # completed and the sponsorship is done.
+            is_done = True
+
         contract_partner = contract.correspondent_id
         child = contract.child_id
         main_languages = request.env["res.lang"].sudo().search([])
@@ -201,7 +212,7 @@ class WebsiteChild(http.Controller):
                 "main_languages": main_languages,
                 "payment_modes": payment_modes,
                 "origins": origins,
-                "done": kwargs.get("done", not contract.is_first_sponsorship),
+                "done": kwargs.get("done", is_done),
                 "face_reveal": kwargs.get("face_reveal"),
             },
         )


### PR DESCRIPTION
When an SMS sponsorship reminder is sent but we have all informations of the sponsorship and contract state=='waiting', instead of displaying a bad request page we display a new information page depending on the language of the partner.
This solution should be validated mostly for the design part (how the page should look like).