### PR TITLE
T2474 nico refactor letters page with new design

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -12,23 +12,17 @@ from odoo.http import request
 
 
 class MyCompassionChildrenController(http.Controller):
-    def _get_sponsored_child_and_check_access(self, child_id):
+    def _check_sponsored_child_access(self, child):
         """
         Private helper to securely fetch a sponsored child.
         Ensures the current user is a sponsor of the requested child.
-        :param child_id: The ID of the child to fetch.
-        :return: A recordset of the 'compassion.child'.
+        :param child: The requested child record to fetch.
         :raises: odoo.exceptions.AccessError if the user is not an active sponsor.
         """
-        partner = request.env.user.partner_id
-        child = partner.sponsorship_ids.filtered(
-            lambda s: s.child_id.id == child_id
-        ).mapped("child_id")
-        if not child:
+        if not request.env.user.partner_id.sponsorship_ids.mapped("child_id") & child:
             raise AccessError(
                 _("You are not authorized to view this child's information.")
             )
-        return child
 
     def _get_timeline_records(self, partner_id, child_id, offset=0, limit=9):
         """Private helper to fetch a paginated list of timeline records."""
@@ -88,7 +82,7 @@ class MyCompassionChildrenController(http.Controller):
     def my2_render_child_timeline_page(self, child, **kwargs):
         """Renders the main timeline page with the initial batch of records."""
         try:
-            child = self._get_sponsored_child_and_check_access(child.id)
+            self._check_sponsored_child_access(child)
         except AccessError:
             return request.redirect("/my2/children/")
 
@@ -125,7 +119,7 @@ class MyCompassionChildrenController(http.Controller):
     def my2_get_child_timeline_items(self, child, **kwargs):
         """API endpoint for infinite scroll. Returns a rendered HTML snippet."""
         try:
-            child = self._get_sponsored_child_and_check_access(child.id)
+            self._check_sponsored_child_access(child)
         except AccessError:
             # For an API, it's better to return an empty or error response
             # than to redirect.

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -128,7 +128,10 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
     )
     def my2_render_new_letter_page(self, child, **kwargs):
         partner = request.env.user.partner_id
-        self._check_sponsored_child_access(child)
+        try:
+            self._check_sponsored_child_access(child)
+        except AccessError:
+            return request.redirect("/my2/children/")
         # Retrieve the letter templates
         templates = (
             request.env["correspondence.template"]
@@ -179,6 +182,7 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             child_id = int(post.get("child_id"))
             child = request.env["compassion.child"].browse(child_id)
             self._check_sponsored_child_access(child)
+            template_id = int(post.get("template_id"))
         except (AccessError, ValueError, TypeError):
             return {"error": "Something went wrong."}
 
@@ -197,7 +201,7 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
                 ]
             ),
             "body": post.get("letter_body"),
-            "template_id": int(post.get("template_id")),
+            "template_id": template_id,
             "image_ids": attachments,
             "source": post.get("source"),
         }

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -6,6 +6,9 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+import calendar
+from datetime import date
+
 from werkzeug.exceptions import NotFound
 
 from odoo import http
@@ -14,44 +17,101 @@ from odoo.http import request
 
 class MyCompassionCorrespondenceController(http.Controller):
     @http.route(
-        '/my2/children/<model("compassion.child"):child>/letters',
+        ["/my2/children/letters", "/my2/children/letters/<int:child_id>"],
         type="http",
         auth="user",
         website=True,
         sitemap=False,
     )
-    def my2_render_child_letters_page(self, child, **kwargs):
+    def my2_render_child_letters_page(self, child_id=None, **kwargs):
         partner = request.env.user.partner_id
         children_sponsored_by_partner = partner.sponsorship_ids.child_id
-
-        letters = request.env["correspondence"].search(
-            [("partner_id", "=", partner.id)], order="create_date DESC"
+        current_year = date.today().year
+        filter_child = next(
+            (c for c in children_sponsored_by_partner if c.id == child_id), None
         )
 
-        if child in children_sponsored_by_partner:
-            breadcrumbs = [
-                {"name": "Children", "url": "/my2/children/", "active": False},
-                {
-                    "name": child.preferred_name,
-                    "url": "/my2/children/" + str(child.id),
-                    "active": True,
-                },
-                {
-                    "name": "Letters",
-                    "url": "/my2/children/" + str(child.id) + "/letters",
-                    "active": True,
-                },
-            ]
+        # Helper function to safely parse integers from query params
+        def safe_int(value, default):
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                return default
 
-            return request.render(
-                "my_compassion.my2_child_letters_page",
-                {
-                    "compassion_child": child,
-                    "letters": letters,
-                    "breadcrumbs": breadcrumbs,
+        # Filtering params
+        page = safe_int(kwargs.get("page"), 1)
+        year_from = safe_int(kwargs.get("year_from"), 1900)
+        year_to = safe_int(kwargs.get("year_to"), current_year)
+        month_from = safe_int(kwargs.get("month_from"), 1)
+        month_to = safe_int(kwargs.get("month_to"), 12)
+        letter_type = kwargs.get("type")
+        sort_order = kwargs.get("sort", "newest")
+        nr_filters_applied = 0
+
+        # Build filter date range
+        last_day = calendar.monthrange(year_to, month_to)[1]
+        from_date = date(year_from, month_from, 1)
+        to_date = date(year_to, month_to, last_day)
+
+        # Build the domain of the filtering of the letters
+        filter_domain = [("partner_id", "=", partner.id)]
+
+        if filter_child:
+            filter_domain.append(("child_id", "=", child_id))
+            nr_filters_applied += 1
+        filter_domain.append(("create_date", ">=", from_date))
+        filter_domain.append(("create_date", "<=", to_date))
+        if (
+            year_from > 1900
+            or year_to < current_year
+            or month_from > 1
+            or month_to < 12
+        ):
+            nr_filters_applied += 1
+        if letter_type:
+            filter_domain.append(("direction", "=", letter_type))
+            nr_filters_applied += 1
+        order = "create_date DESC" if sort_order == "newest" else "create_date ASC"
+        if sort_order == "oldest":
+            nr_filters_applied += 1
+
+        # Pagination setup
+        letters_per_page = 12
+        offset = (page - 1) * letters_per_page
+        total_letters = request.env["correspondence"].search_count(filter_domain)
+        total_pages = max(1, -(-total_letters // letters_per_page))
+
+        letters = request.env["correspondence"].search(
+            filter_domain, order=order, offset=offset, limit=letters_per_page
+        )
+
+        # Fetch the filtered letters from the database
+        letter_children_pairs = []
+        for letter in letters:
+            if letter.child_id:
+                letter_children_pairs.append((letter, letter.child_id))
+
+        return request.render(
+            "my_compassion.my2_child_letters_page",
+            {
+                "child_id": child_id,
+                "letter_children_pairs": letter_children_pairs,
+                "filter_child": filter_child,
+                "current_year": current_year,
+                "children_list": children_sponsored_by_partner,
+                "current_page": page,
+                "total_pages": total_pages,
+                "filters": {
+                    "year_from": year_from,
+                    "year_to": year_to,
+                    "month_from": month_from,
+                    "month_to": month_to,
+                    "type": letter_type,
+                    "sort": sort_order,
                 },
-            )
-        raise NotFound()
+                "nr_filters_applied": nr_filters_applied,
+            },
+        )
 
     @http.route(
         '/my2/children/<model("compassion.child"):child>/letter/new',
@@ -101,93 +161,95 @@ class MyCompassionCorrespondenceController(http.Controller):
             )
         raise NotFound()
 
-    @http.route(
-        "/my2/children/letter/new",
-        type="json",
-        auth="user",
-        methods=["POST"],
-        sitemap=False,
-    )
-    def my2_create_new_letter(self, **post):
-        """
-        Used in my2_new_letter.js for sending the new letter form data
-        """
 
-        # Retrieve JSON data
-        child_id = int(post.get("child_id"))
-        template_id = post.get("template_id")
-        letter_body = post.get("letter_body")
-        source = post.get("source")
-        attachments = post.get("attachments")
-        mode = post.get("mode")  # Either send or preview
+@http.route(
+    "/my2/children/letter/new",
+    type="json",
+    auth="user",
+    methods=["POST"],
+    sitemap=False,
+)
+def my2_create_new_letter(self, **post):
+    """
+    Used in my2_new_letter.js for sending the new letter form data
+    """
 
-        # Retrieve related user data
-        partner = request.env.user.partner_id
-        children_sponsored_by_partner = partner.sponsorship_ids.child_id
+    # Retrieve JSON data
+    child_id = int(post.get("child_id"))
+    template_id = post.get("template_id")
+    letter_body = post.get("letter_body")
+    source = post.get("source")
 
-        # Retrieve the child object already instantiated
-        selected_child = None
-        for compassion_child in children_sponsored_by_partner:
-            if compassion_child.id == child_id:
-                selected_child = compassion_child
+    attachments = post.get("attachments")
+    mode = post.get("mode")  # Either send or preview
 
-        # This is from legacy, it should be refactored in my opinion
-        datas = []
-        for file in attachments:
-            if isinstance(file, dict) and "content" in file:
-                datas.append(
-                    (
-                        0,
-                        0,
-                        {
-                            "datas": file["content"],
-                            "name": file["filename"],
-                        },
-                    )
+    # Retrieve related user data
+    partner = request.env.user.partner_id
+    children_sponsored_by_partner = partner.sponsorship_ids.child_id
+
+    # Retrieve the child object already instantiated
+    selected_child = None
+    for compassion_child in children_sponsored_by_partner:
+        if compassion_child.id == child_id:
+            selected_child = compassion_child
+
+    # This is from legacy, it should be refactored in my opinion
+    datas = []
+    for file in attachments:
+        if isinstance(file, dict) and "content" in file:
+            datas.append(
+                (
+                    0,
+                    0,
+                    {
+                        "datas": file["content"],
+                        "name": file["filename"],
+                    },
                 )
+            )
 
-        letter_values = {
-            "name": f"{source}-{selected_child.local_id}",
-            "selection_domain": str(
-                [
-                    ("child_id.local_id", "=", selected_child.local_id),
-                    ("state", "not in", ["draft", "cancelled"]),
-                ]
-            ),
-            "body": letter_body,
-            "template_id": int(template_id),
-            "image_ids": datas,
-            "source": source,
+    letter_values = {
+        "name": f"{source}-{selected_child.local_id}",
+        "selection_domain": str(
+            [
+                ("child_id.local_id", "=", selected_child.local_id),
+                ("state", "not in", ["draft", "cancelled"]),
+            ]
+        ),
+        "body": letter_body,
+        "template_id": int(template_id),
+        "image_ids": datas,
+        "source": source,
+    }
+
+    # Retrieved code from legacy, wondering use case ?
+    language = request.env["langdetect"].sudo().detect_language(letter_body)
+    if language:
+        letter_values["language_id"] = language.id
+
+    letter_generator = (
+        request.env["correspondence.s2b.generator"].sudo().create(letter_values)
+    )
+
+    # I don't understand why was it made like this
+    # This is how legacy retrieves the sponsorship_id...
+    letter_generator.onchange_domain()
+
+    letter_generator.preview()
+
+    if mode == "send":
+        letter_generator.generate_letters_job()
+
+    if letter_generator:
+        return {
+            "preview_url": f"{request.httprequest.host_url}web/image"
+            f"/{letter_generator._name}/{letter_generator.id}"
+            f"/preview_pdf",
+            "letter_values": letter_values,
+            "generator_id": letter_generator.id,
         }
 
-        # Retrieved code from legacy, wondering use case ?
-        language = request.env["langdetect"].sudo().detect_language(letter_body)
-        if language:
-            letter_values["language_id"] = language.id
-
-        letter_generator = (
-            request.env["correspondence.s2b.generator"].sudo().create(letter_values)
-        )
-
-        # I don't understand why was it made like this
-        # This is how legacy retrieves the sponsorship_id...
-        letter_generator.onchange_domain()
-
-        letter_generator.preview()
-
-        if mode == "send":
-            letter_generator.generate_letters_job()
-
-        if letter_generator:
-            return {
-                "preview_url": f"{request.httprequest.host_url}web/image"
-                f"/{letter_generator._name}/{letter_generator.id}"
-                f"/preview_pdf",
-                "letter_values": letter_values,
-                "generator_id": letter_generator.id,
-            }
-
-        else:
-            return {
-                "error": "Something went wrong.",
-            }
+    else:
+        return {
+            "error": "Something went wrong.",
+        }

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -9,27 +9,30 @@
 import calendar
 from datetime import date
 
-from werkzeug.exceptions import NotFound
+import babel
 
 from odoo import http
+from odoo.exceptions import AccessError
 from odoo.http import request
 
+from .my2_children import MyCompassionChildrenController
 
-class MyCompassionCorrespondenceController(http.Controller):
+
+class MyCompassionCorrespondenceController(MyCompassionChildrenController):
     @http.route(
-        ["/my2/children/letters", "/my2/children/letters/<int:child_id>"],
+        [
+            "/my2/children/letters",
+            "/my2/children/letters/<model('compassion.child'):child>",
+        ],
         type="http",
         auth="user",
         website=True,
         sitemap=False,
     )
-    def my2_render_child_letters_page(self, child_id=None, **kwargs):
+    def my2_render_child_letters_page(self, child=None, **kwargs):
         partner = request.env.user.partner_id
         children_sponsored_by_partner = partner.sponsorship_ids.child_id
         current_year = date.today().year
-        filter_child = next(
-            (c for c in children_sponsored_by_partner if c.id == child_id), None
-        )
 
         # Helper function to safely parse integers from query params
         def safe_int(value, default):
@@ -56,9 +59,13 @@ class MyCompassionCorrespondenceController(http.Controller):
         # Build the domain of the filtering of the letters
         filter_domain = [("partner_id", "=", partner.id)]
 
-        if filter_child:
-            filter_domain.append(("child_id", "=", child_id))
-            nr_filters_applied += 1
+        if child:
+            try:
+                self._check_sponsored_child_access(child)
+                filter_domain.append(("child_id", "=", child.id))
+                nr_filters_applied += 1
+            except AccessError:
+                child = None
         filter_domain.append(("create_date", ">=", from_date))
         filter_domain.append(("create_date", "<=", to_date))
         if (
@@ -85,18 +92,16 @@ class MyCompassionCorrespondenceController(http.Controller):
             filter_domain, order=order, offset=offset, limit=letters_per_page
         )
 
-        # Fetch the filtered letters from the database
-        letter_children_pairs = []
-        for letter in letters:
-            if letter.child_id:
-                letter_children_pairs.append((letter, letter.child_id))
+        # Month names in the current language
+        lang = request.env.context.get("lang", partner.lang)
+        locale = babel.Locale.parse(lang)
+        months = [(i, locale.months["format"]["wide"][i]) for i in range(1, 13)]
 
         return request.render(
             "my_compassion.my2_child_letters_page",
             {
-                "child_id": child_id,
-                "letter_children_pairs": letter_children_pairs,
-                "filter_child": filter_child,
+                "letters": letters,
+                "filter_child": child,
                 "current_year": current_year,
                 "children_list": children_sponsored_by_partner,
                 "current_page": page,
@@ -110,6 +115,7 @@ class MyCompassionCorrespondenceController(http.Controller):
                     "sort": sort_order,
                 },
                 "nr_filters_applied": nr_filters_applied,
+                "months": months,
             },
         )
 
@@ -122,134 +128,95 @@ class MyCompassionCorrespondenceController(http.Controller):
     )
     def my2_render_new_letter_page(self, child, **kwargs):
         partner = request.env.user.partner_id
-        children_sponsored_by_partner = partner.sponsorship_ids.child_id
-
-        if child in children_sponsored_by_partner:
-            # Retrieve the letter templates
-            templates = (
-                request.env["correspondence.template"]
-                .search(
-                    [
-                        ("active", "=", True),
-                        ("website_published", "=", True),
-                    ]
-                )
-                # Sort the templates alphabetically, placing "Christmas"
-                # templates at the beginning
-                # "0" is special sorting key because it comes
-                # before any letter in ASCII order.
-                .sorted(lambda t: "0" if "christmas" in t.name.lower() else t.name)
+        self._check_sponsored_child_access(child)
+        # Retrieve the letter templates
+        templates = (
+            request.env["correspondence.template"]
+            .search(
+                [
+                    ("active", "=", True),
+                    ("website_published", "=", True),
+                ]
             )
+            # Sort the templates alphabetically, placing "Christmas"
+            # templates at the beginning
+            # "0" is special sorting key because it comes
+            # before any letter in ASCII order.
+            .sorted(lambda t: "0" if "christmas" in t.name.lower() else t.name)
+        )
 
-            breadcrumbs = [
-                {"name": "Children", "url": "/my2/children/", "active": False},
-                {
-                    "name": "New Letter",
-                    "url": "/my2/children/" + str(child.id) + "/letter/new",
-                    "active": True,
-                },
-            ]
+        breadcrumbs = [
+            {"name": "Children", "url": "/my2/children/", "active": False},
+            {
+                "name": "New Letter",
+                "url": "/my2/children/" + str(child.id) + "/letter/new",
+                "active": True,
+            },
+        ]
 
-            return request.render(
-                "my_compassion.my2_new_letter_page",
-                {
-                    "selected_child": child,
-                    "sponsorship_ids": partner.sponsorship_ids,
-                    "templates": templates,
-                    "breadcrumbs": breadcrumbs,
-                },
-            )
-        raise NotFound()
+        return request.render(
+            "my_compassion.my2_new_letter_page",
+            {
+                "selected_child": child,
+                "sponsorship_ids": partner.sponsorship_ids,
+                "templates": templates,
+                "breadcrumbs": breadcrumbs,
+            },
+        )
 
-
-@http.route(
-    "/my2/children/letter/new",
-    type="json",
-    auth="user",
-    methods=["POST"],
-    sitemap=False,
-)
-def my2_create_new_letter(self, **post):
-    """
-    Used in my2_new_letter.js for sending the new letter form data
-    """
-
-    # Retrieve JSON data
-    child_id = int(post.get("child_id"))
-    template_id = post.get("template_id")
-    letter_body = post.get("letter_body")
-    source = post.get("source")
-
-    attachments = post.get("attachments")
-    mode = post.get("mode")  # Either send or preview
-
-    # Retrieve related user data
-    partner = request.env.user.partner_id
-    children_sponsored_by_partner = partner.sponsorship_ids.child_id
-
-    # Retrieve the child object already instantiated
-    selected_child = None
-    for compassion_child in children_sponsored_by_partner:
-        if compassion_child.id == child_id:
-            selected_child = compassion_child
-
-    # This is from legacy, it should be refactored in my opinion
-    datas = []
-    for file in attachments:
-        if isinstance(file, dict) and "content" in file:
-            datas.append(
-                (
-                    0,
-                    0,
-                    {
-                        "datas": file["content"],
-                        "name": file["filename"],
-                    },
-                )
-            )
-
-    letter_values = {
-        "name": f"{source}-{selected_child.local_id}",
-        "selection_domain": str(
-            [
-                ("child_id.local_id", "=", selected_child.local_id),
-                ("state", "not in", ["draft", "cancelled"]),
-            ]
-        ),
-        "body": letter_body,
-        "template_id": int(template_id),
-        "image_ids": datas,
-        "source": source,
-    }
-
-    # Retrieved code from legacy, wondering use case ?
-    language = request.env["langdetect"].sudo().detect_language(letter_body)
-    if language:
-        letter_values["language_id"] = language.id
-
-    letter_generator = (
-        request.env["correspondence.s2b.generator"].sudo().create(letter_values)
+    @http.route(
+        "/my2/children/letter/new",
+        type="json",
+        auth="user",
+        methods=["POST"],
+        sitemap=False,
     )
+    def my2_create_new_letter(self, **post):
+        """
+        Used in my2_new_letter.js for sending the new letter form data
+        """
+        try:
+            child_id = int(post.get("child_id"))
+            child = request.env["compassion.child"].browse(child_id)
+            self._check_sponsored_child_access(child)
+        except (AccessError, ValueError, TypeError):
+            return {"error": "Something went wrong."}
 
-    # I don't understand why was it made like this
-    # This is how legacy retrieves the sponsorship_id...
-    letter_generator.onchange_domain()
+        attachments = [
+            (0, 0, {"datas": file["content"], "name": file["filename"]})
+            for file in post.get("attachments", [])
+            if isinstance(file, dict) and "content" in file
+        ]
 
-    letter_generator.preview()
-
-    if mode == "send":
-        letter_generator.generate_letters_job()
-
-    if letter_generator:
-        return {
-            "preview_url": f"{request.httprequest.host_url}web/image"
-            f"/{letter_generator._name}/{letter_generator.id}"
-            f"/preview_pdf",
-            "letter_values": letter_values,
-            "generator_id": letter_generator.id,
+        letter_values = {
+            "name": f"{post.get('source')}-{child.local_id}",
+            "selection_domain": str(
+                [
+                    ("child_id.local_id", "=", child.local_id),
+                    ("state", "not in", ["draft", "cancelled"]),
+                ]
+            ),
+            "body": post.get("letter_body"),
+            "template_id": int(post.get("template_id")),
+            "image_ids": attachments,
+            "source": post.get("source"),
         }
 
-    else:
+        letter_generator = (
+            request.env["correspondence.s2b.generator"].sudo().create(letter_values)
+        )
+        if not letter_generator:
+            return {"error": "Something went wrong."}
+
+        letter_generator.onchange_domain()
+        letter_generator.preview()
+
+        if post.get("mode") == "send":
+            letter_generator.generate_letters_job()
+
         return {
-            "error": "Something went wrong.",
+            "preview_url": f"{request.httprequest.host_url}web/image"
+            f"/{letter_generator._name}/{letter_generator.id}/preview_pdf",
+            "letter_values": letter_values,
+            "generator_id": letter_generator.id,
         }

--- a/my_compassion/static/src/css/child_letters.css
+++ b/my_compassion/static/src/css/child_letters.css
@@ -1,0 +1,34 @@
+/*
+    This stylesheet concerns the my2_child_letters page
+    templates/pages/my2_child_letters.js
+*/
+
+.btn-custom-toggle.active {
+    background-color: #1d42a5 !important;
+    color: white !important;
+    border-color: #1d42a5 !important;
+}
+
+.border-left-pill {
+    border-top-left-radius: 25px !important;
+    border-bottom-left-radius: 25px !important;
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    box-shadow: none !important;
+}
+
+.border-right-pill {
+    border-top-right-radius: 25px !important;
+    border-bottom-right-radius: 25px !important;
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    box-shadow: none !important;
+}
+
+.border-pill {
+    border-top-right-radius: 25px !important;
+    border-bottom-right-radius: 25px !important;
+    border-top-left-radius: 25px !important;
+    border-bottom-left-radius: 25px !important;
+    box-shadow: none !important;
+}

--- a/my_compassion/static/src/css/letter_card.css
+++ b/my_compassion/static/src/css/letter_card.css
@@ -2,11 +2,86 @@
     This stylesheet concerns the my2_letter_card component
     templates/components/my2_letter_card.xml
 */
-.letter-icon {
-    font-size: 3rem;
-    color: var(--compassion-blue);
+
+/* Envelope icon */
+.my2-envelope {
+    --env-width: 84px;
+    --env-height: 54px;
+    width: var(--env-width);
+    height: var(--env-height);
+    position: relative;
+    display: block;
 }
 
-.new-letter-created {
-    border: 0.2rem solid deepskyblue;
+/* Color variants */
+.envelope--blue {
+    --color-env: #6a8ef2;
+    --color-flap: #11265e;
+}
+.envelope--green {
+    --color-env: #499e57;
+    --color-flap: #235339;
+}
+
+/* Envelope components */
+.my2-envelope .env-body {
+    width: 100%;
+    height: 100%;
+    background-color: var(--color-env);
+}
+.my2-envelope .env-flap {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-left: calc(var(--env-width) / 2) solid transparent;
+    border-right: calc(var(--env-width) / 2) solid transparent;
+    border-top: calc(var(--env-height) / 2) solid var(--color-flap);
+    transform-origin: top;
+}
+.my2-envelope .env-pocket {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-left: calc(var(--env-width) / 2) solid var(--color-env);
+    border-right: calc(var(--env-width) / 2) solid var(--color-env);
+    border-bottom: calc(var(--env-height) / 2) solid var(--color-env);
+    border-top: calc(var(--env-height) / 2) solid transparent;
+}
+.my2-envelope .env-letter {
+    position: absolute;
+    top: calc(var(--env-height) * 0.05);
+    left: calc(var(--env-width) * 0.05);
+    width: 90%;
+    height: 90%;
+    background-color: #fff;
+    border-radius: 4px;
+    overflow: hidden;
+}
+/* Preview on the letter */
+.my2-envelope .env-letter iframe {
+    border: none;
+    transform: scale(0.1) translateY(-10%) translateX(-5%);
+    transform-origin: top left;
+    width: 1200%;
+    height: 1200%;
+}
+
+/* Envelope animation */
+.open .env-flap {
+    transform: rotateX(180deg);
+    transition: transform 0.8s ease;
+    z-index: 2;
+}
+.open .env-letter {
+    transform: translateY(-40%);
+    transition: transform 0.4s ease 0.8s;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    z-index: 1;
+}
+.open .env-pocket {
+    z-index: 3;
 }

--- a/my_compassion/static/src/js/my2_child_letters.js
+++ b/my_compassion/static/src/js/my2_child_letters.js
@@ -1,0 +1,72 @@
+/**
+ * Handles the pagination and adds filtering arguments in the url for the my2_child_letters.xml page.
+ * Used in /templates/pages/my2_child_letters.xml.
+ */
+
+document.addEventListener("DOMContentLoaded", function () {
+    const okBtn = document.getElementById("filterOkBtn");
+
+    // Letter animation
+    document.querySelectorAll(".my2-envelope").forEach((envelope) => {
+        envelope.addEventListener("click", function () {
+            envelope.classList.add("open");
+            const letter = envelope.querySelector(".env-letter");
+
+            setTimeout(() => {
+                if (letter) {
+                    letter.style.zIndex = "3";
+                }
+            }, 800);
+
+            setTimeout(function () {
+                const href = envelope.getAttribute("href");
+                if (href) {
+                    window.location.href = href;
+                }
+            }, 1200);
+        });
+    });
+
+    // Pagination: Next Page
+    document.getElementById("nextPageBtn")?.addEventListener("click", () => {
+        const currentUrl = new URL(window.location.href);
+        const currentPage = parseInt(currentUrl.searchParams.get("page") || "1", 10);
+        currentUrl.searchParams.set("page", currentPage + 1);
+        window.location.href = currentUrl.toString();
+    });
+
+    // Pagination: Previous Page
+    document.getElementById("prevPageBtn")?.addEventListener("click", () => {
+        const currentUrl = new URL(window.location.href);
+        const currentPage = parseInt(currentUrl.searchParams.get("page") || "1", 10);
+        if (currentPage > 1) {
+            currentUrl.searchParams.set("page", currentPage - 1);
+            window.location.href = currentUrl.toString();
+        }
+    });
+
+    // Apply filters and sorting when OK button is clicked
+    if (okBtn) {
+        okBtn.addEventListener("click", function () {
+            const filterYearFrom = document.getElementById("yearDropdownFrom")?.value || "";
+            const filterYearTo = document.getElementById("yearDropdownTo")?.value || "";
+            const filterMonthFrom = document.getElementById("monthDropdownFrom")?.value || "";
+            const filterMonthTo = document.getElementById("monthDropdownTo")?.value || "";
+            const sort = document.querySelector('input[name="sortOptions"]:checked')?.value || "newest";
+            const redirect_child_id = document.getElementById("childrenDropdown")?.value || "";
+            const selectedType = document.querySelector('input[name="type"]:checked')?.value || "";
+
+            const url = new URL(window.location.origin + "/my2/children/letters");
+            if (redirect_child_id) url.pathname += `/${redirect_child_id}`;
+            if (filterYearFrom) url.searchParams.set("year_from", filterYearFrom);
+            if (filterYearTo) url.searchParams.set("year_to", filterYearTo);
+            if (filterMonthFrom) url.searchParams.set("month_from", filterMonthFrom);
+            if (filterMonthTo) url.searchParams.set("month_to", filterMonthTo);
+            if (selectedType) url.searchParams.set("type", selectedType);
+            url.searchParams.set("sort", sort);
+            url.searchParams.set("page", 1);
+
+            window.location.href = url.toString();
+        });
+    }
+});

--- a/my_compassion/static/src/js/my2_child_letters.js
+++ b/my_compassion/static/src/js/my2_child_letters.js
@@ -2,9 +2,12 @@
  * Handles the pagination and adds filtering arguments in the url for the my2_child_letters.xml page.
  * Used in /templates/pages/my2_child_letters.xml.
  */
+odoo.define("my_compassion.my2_child_letters", function (require) {
+    "use strict";
 
-document.addEventListener("DOMContentLoaded", function () {
     const okBtn = document.getElementById("filterOkBtn");
+    const ToastService = require("my_compassion.toast_service");
+    const _t = require("web.core")._t;
 
     // Letter animation
     document.querySelectorAll(".my2-envelope").forEach((envelope) => {
@@ -69,4 +72,48 @@ document.addEventListener("DOMContentLoaded", function () {
             window.location.href = url.toString();
         });
     }
+
+    // Share button functionality
+    document.querySelectorAll(".js_share_letter").forEach((shareButton) => {
+        shareButton.addEventListener("click", function (ev) {
+            ev.preventDefault();
+            const shareData = {
+                title: this.dataset.shareTitle,
+                text: this.dataset.shareText,
+                url: this.dataset.shareUrl,
+            };
+
+            // Ensure the URL exists before proceeding
+            if (!shareData.url) {
+                console.error("Share URL is not available for this item.");
+                ToastService.error(_t("Sorry, this letter cannot be shared."));
+                return;
+            }
+
+            // This works only in secure contexts (HTTPS)
+            if (navigator.share) {
+                try {
+                    navigator.share(shareData);
+                    console.log("Letter shared successfully");
+                } catch (err) {
+                    console.error("Share failed:", err.message);
+                    ToastService.error(_t("Failed to share letter."));
+                }
+            } else if (navigator.clipboard) {
+                // Fallback for browsers that do not support the Web Share API
+                navigator.clipboard
+                    .writeText(shareData.url)
+                    .then(() => {
+                        ToastService.success(_t("Link copied to clipboard!"));
+                    })
+                    .catch((err) => {
+                        console.error("Could not copy text: ", err);
+                        ToastService.error(_t("Failed to copy link."));
+                    });
+            } else {
+                // Fallback for browsers that do not support the Web Share API or Clipboard API
+                ToastService.error(_t("Sharing is not supported in this browser. Please share your letter manually."));
+            }
+        });
+    });
 });

--- a/my_compassion/templates/components/my2_letter_card.xml
+++ b/my_compassion/templates/components/my2_letter_card.xml
@@ -8,10 +8,10 @@
 
     Props:
     - letter (record): The related letter object.
-    - child (record): The child associated with the letter.
 -->
 <odoo>
     <template id="my2_letter_card_component" name="Letter Card Component">
+        <t t-set="child" t-value="letter.child_id" />
         <link rel="stylesheet" href="/my_compassion/static/src/css/letter_card.css" />
         <div class="position-relative d-flex shadow-sm rounded-4  h-100">
             <!-- Icon at the left -->
@@ -24,6 +24,11 @@
                     <div class="env-body" />
                     <div class="env-letter">
                         <!-- Letter preview -->
+                        <!-- TODO Using an iframe for each letter card to show a preview can lead to significant performance issues.
+                              For better performance, consider lazy-loading the src of the <iframe>.
+                              You could set the src attribute via JavaScript only when the card is about to become visible in the viewport
+                              (e.g., using IntersectionObserver) or when the user initiates the envelope-opening animation.
+                        -->
                         <iframe
                             t-attf-src="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
                             type="application/pdf"
@@ -39,16 +44,17 @@
             <div class="flex-grow-1 d-flex flex-column ml-2 mr-2 mb-2 mt-4">
                 <!-- Top row: Title (left) and Dropdown (right) -->
                 <div class="d-flex justify-content-between align-items-start mb-4">
-                    <t
-                        t-set="label"
-                        t-value="'From ' + child.preferred_name if letter.direction != 'Supporter To Beneficiary' else 'To ' + child.preferred_name"
-                    />
-                    <t
-                        t-set="color_class"
-                        t-value="'text-core-blue' if letter.direction != 'Supporter To Beneficiary' else ''"
-                    />
-                    <div t-attf-class="h5 #{color_class}">
-                        <t t-esc="label" />
+                    <div
+                        t-attf-class="h5 #{'text-core-blue' if letter.direction != 'Supporter To Beneficiary' else ''}"
+                    >
+                        <t t-if="letter.direction != 'Supporter To Beneficiary'">
+                            <span>From</span>
+                            <t t-esc="child.preferred_name" />
+                        </t>
+                        <t t-else="">
+                            <span>To</span>
+                            <t t-esc="child.preferred_name" />
+                        </t>
                     </div>
                     <!-- Dots button & dropdown menu -->
                     <div class="dropdown">

--- a/my_compassion/templates/components/my2_letter_card.xml
+++ b/my_compassion/templates/components/my2_letter_card.xml
@@ -8,75 +8,97 @@
 
     Props:
     - letter (record): The related letter object.
+    - child (record): The child associated with the letter.
 -->
 <odoo>
     <template id="my2_letter_card_component" name="Letter Card Component">
-        <link rel="stylesheet" href="/my_compassion/static/src/css/details_card.css" />
         <link rel="stylesheet" href="/my_compassion/static/src/css/letter_card.css" />
-        <div class="details-card w-100" t-att-data-generator-id="letter.generator_id.id">
-            <div class="details-card-body">
-                <div class="row align-items-center">
-                    <!-- Left part of the card with the letter icon -->
-                    <div class="col-5">
-                        <div class="ml-3">
-                            <i
-                                name="iconLetter"
-                                t-att-class="'fa letter-icon ' + (letter.email_read and 'fa-envelope-open-o' or 'fa-envelope-o')"
-                            />
-                        </div>
+        <div class="position-relative d-flex shadow-sm rounded-4  h-100">
+            <!-- Icon at the left -->
+            <div class="envelope">
+                <div
+                    id="envelope-{{ letter.uuid }}"
+                    t-attf-class="ml-2 mt-4 my2-envelope {{ 'envelope--blue' if letter.direction != 'Supporter To Beneficiary' else 'envelope--green' }}"
+                    t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
+                >
+                    <div class="env-body" />
+                    <div class="env-letter">
+                        <!-- Letter preview -->
+                        <iframe
+                            t-attf-src="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
+                            type="application/pdf"
+                        >
+
+                        </iframe>
                     </div>
-                    <!-- Right part of the card component -->
-                    <div class="col-7 h-100">
-                        <div class="row">
-                            <div class="col-12">
-                                <div class="text-right">
-                                    <p>
-                                        <t t-esc="letter.scanned_date" />
-                                    </p>
-                                    <p>
-                                        <t t-esc="letter.state" />
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Buttons part -->
-                        <div class="row">
-                            <div class="offset-1 col-5">
-                                <a
-                                    t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
-                                    target="_blank"
-                                >
-                                    <button
-                                        name="btn_LetterView"
-                                        type="button"
-                                        class="btn-compassion btn-compassion-blue"
-                                        onclick="onLetterViewButtonClick(event)"
-                                    >
-                                        <span>
-                                            <i class="fa fa-eye" />
-                                        </span>
-                                    </button>
-                                </a>
-                            </div>
-                            <div class="col-5 offset-1">
-                                <a t-attf-href="/b2s_image?id={{letter.uuid}}" t-attf-download="{{letter.name}}">
-                                    <button
-                                        name="btn_download"
-                                        type="button"
-                                        class="btn-compassion btn-compassion-blue"
-                                        onclick="onDownloadButtonClick(event)"
-                                    >
-                                        <span>
-                                            <i class="fa fa-download" />
-                                        </span>
-                                    </button>
-                                </a>
-                            </div>
+                    <div class="env-pocket" />
+                    <div class="env-flap" />
+                </div>
+            </div>
+            <!-- Text block at the right -->
+            <div class="flex-grow-1 d-flex flex-column ml-2 mr-2 mb-2 mt-4">
+                <!-- Top row: Title (left) and Dropdown (right) -->
+                <div class="d-flex justify-content-between align-items-start mb-4">
+                    <t
+                        t-set="label"
+                        t-value="'From ' + child.preferred_name if letter.direction != 'Supporter To Beneficiary' else 'To ' + child.preferred_name"
+                    />
+                    <t
+                        t-set="color_class"
+                        t-value="'text-core-blue' if letter.direction != 'Supporter To Beneficiary' else ''"
+                    />
+                    <div t-attf-class="h5 #{color_class}">
+                        <t t-esc="label" />
+                    </div>
+                    <!-- Dots button & dropdown menu -->
+                    <div class="dropdown">
+                        <button
+                            class="btn btn-link p-0 border-0"
+                            type="button"
+                            t-att-id="'dropdownMenuButton' + str(letter.id)"
+                            data-toggle="dropdown"
+                            aria-expanded="false"
+                        >
+                            <span class="icon-dots-vertical" />
+                        </button>
+                        <div
+                            class="dropdown-menu border-low-black"
+                            t-att-aria-labelledby="'dropdownMenuButton' + str(letter.id)"
+                        >
+                            <a
+                                class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3"
+                                t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
+                            >
+                                Preview
+                                <i class="icon-eye ml-auto" />
+                            </a>
+                            <div class="dropdown-divider border-low-black" />
+                            <a
+                                class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3"
+                                t-attf-href="/b2s_image?id={{letter.uuid}}"
+                                t-attf-download="{{letter.name}}"
+                            >
+                                Download
+                                <i class="icon-download01 ml-auto" />
+                            </a>
+                            <div class="dropdown-divider border-low-black" />
+                            <a class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3" href="#">
+                                Reply
+                                <i class="icon-pencil02 ml-auto" />
+                            </a>
+                            <div class="dropdown-divider border-low-black" />
+                            <a class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3" href="#">
+                                Share
+                                <i class="icon-share06 ml-auto" />
+                            </a>
                         </div>
                     </div>
                 </div>
+                <!-- Letter date -->
+                <div class="mt-auto align-self-end tiny-text text-mid-grey">
+                    <span t-field="letter.create_date" t-options='{"widget": "date","format": "dd MMM. yyyy"}' />
+                </div>
             </div>
         </div>
-        <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters_card_behavior.js" />
     </template>
 </odoo>

--- a/my_compassion/templates/components/my2_letter_card.xml
+++ b/my_compassion/templates/components/my2_letter_card.xml
@@ -88,12 +88,22 @@
                                 <i class="icon-download01 ml-auto" />
                             </a>
                             <div class="dropdown-divider border-low-black" />
-                            <a class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3" href="#">
+                            <a
+                                class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3"
+                                t-attf-href="/my2/children/{{child.id}}/letter/new"
+                            >
                                 Reply
                                 <i class="icon-pencil02 ml-auto" />
                             </a>
                             <div class="dropdown-divider border-low-black" />
-                            <a class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3" href="#">
+                            <a
+                                class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3 js_share_letter"
+                                href="javascript:void(0);"
+                                t-att-data-share-url="request.httprequest.url_root + 'b2s_image?id=%s&amp;disposition=inline&amp;file_type=pdf' % letter.uuid"
+                                t-attf-data-share-title="Letter from #{child.preferred_name}"
+                                t-attf-data-share-text="Check out this letter from #{child.preferred_name}!"
+                                role="button"
+                            >
                                 Share
                                 <i class="icon-share06 ml-auto" />
                             </a>

--- a/my_compassion/templates/my2_assets.xml
+++ b/my_compassion/templates/my2_assets.xml
@@ -6,9 +6,9 @@
     <!-- Make all pages load global.css file -->
     <template id="my_compassion_assets" name="My Compassion 2.0 assets" inherit_id="website.assets_frontend">
         <xpath expr="." position="inside">
-            <script type="text/xml" src="/my_compassion/static/src/xml/toast_notification.xml" />
             <script type="text/javascript" src="/my_compassion/static/src/js/toast_notification.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/toast_service.js" />
+            <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/toast_notification.css" />
         </xpath>
         <!-- Loads files at the end of page -->

--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -79,14 +79,6 @@
                                         <div class="w-60">
                                             <t t-set="id" t-value="'monthDropdownFrom'" />
                                             <t t-set="name" t-value="'month_from'" />
-                                            <t
-                                                t-set="months"
-                                                t-value="[
-        (1, 'January'), (2, 'February'), (3, 'March'), (4, 'April'),
-        (5, 'May'), (6, 'June'), (7, 'July'), (8, 'August'),
-        (9, 'September'), (10, 'October'), (11, 'November'), (12, 'December')
-    ]"
-                                            />
                                             <t t-call="theme_compassion_2025.SelectComponent">
                                                 <option value="">Month</option>
                                                 <t t-foreach="months" t-as="month">
@@ -122,14 +114,6 @@
                                         <div class="w-60">
                                             <t t-set="id" t-value="'monthDropdownTo'" />
                                             <t t-set="name" t-value="'month'" />
-                                            <t
-                                                t-set="months"
-                                                t-value="[
-        (1, 'January'), (2, 'February'), (3, 'March'), (4, 'April'),
-        (5, 'May'), (6, 'June'), (7, 'July'), (8, 'August'),
-        (9, 'September'), (10, 'October'), (11, 'November'), (12, 'December')
-    ]"
-                                            />
                                             <t t-call="theme_compassion_2025.SelectComponent">
                                                 <option value="">Month</option>
                                                 <t t-foreach="months" t-as="month">
@@ -249,19 +233,14 @@
             </div>
             <!-- Letters -->
             <div id="lettersContainer" class="row mb-3">
-                <t t-foreach="letter_children_pairs" t-as="pair" t-foreach-index="i">
-                    <t t-set="letter" t-value="pair[0]" />
-                    <t t-set="child" t-value="pair[1]" />
+                <t t-foreach="letters" t-as="letter" t-foreach-index="i">
                     <div
                         class="col-12 col-md-6 col-lg-4 mb-3 mt-3 letter-card"
                         t-att-data-create_date="letter.create_date"
                         t-att-data-type="letter.direction"
                         t-att-data-index="i"
                     >
-                        <t t-call="my_compassion.my2_letter_card_component">
-                            <t t-set="letter" t-value="letter" />
-                            <t t-set="child" t-value="child" />
-                        </t>
+                        <t t-call="my_compassion.my2_letter_card_component" />
                     </div>
                 </t>
             </div>

--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -282,7 +282,5 @@
                 </t>
             </div>
         </t>
-        <!-- JavaScript logic for filter and sort -->
-        <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
     </template>
 </odoo>

--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -3,54 +3,307 @@
     Page: My Compassion 2 Child Letters Page
 
     Description:
-    This page displays all the letters associated with a sponsored child.
+    Displays letters for a specific sponsored child with filtering and sorting options.
 
     Used in route:
     - /my2/children/<model("compassion.child"):child>/letters
 
     Injected data:
-    - compassion_child (record): The related child object.
-    - letters (array of 'correspondence' records): The related sponsorship letters.
+    - compassion_child: the related child record
+    - letters: array of correspondence records
 -->
 <odoo>
     <template id="my2_child_letters_page" name="My Compassion 2 Child Letters Page">
+        <link rel="stylesheet" href="/my_compassion/static/src/css/child_letters.css" />
         <t t-call="website.layout">
             <div class="container">
-                <!-- Calling breadcrumb component -->
-                <t t-call="my_compassion.my2_breadcrumbs" />
-                <div class="row mb-2">
-                    <div class="col-12">
-                        <!-- Using children_profile component -->
-                        <t t-call="my_compassion.my2_children_profile_component">
-                            <!-- The data we are passing to the children_profile_component -->
-                            <t t-set="compassion_child" t-value="compassion_child" />
+                <!-- Title -->
+                <div class="mb-4">
+                    <t t-call="theme_compassion_2025.TitleComponent">
+                        <t t-set="title_content" t-value="'Your inbox'" />
+                        <t t-set="color" t-value="'core-blue'" />
+                        <t t-set="underline_color" t-value="'low-yellow'" />
+                        <t t-set="show_underline" t-value="True" />
+                        <t t-set="title_size" t-value="'md'" />
+                    </t>
+                </div>
+                <div class="text-center mb-3">
+                    <!-- Button for opening the filter modal -->
+                    <a id="filterToggleBtn" data-toggle="modal" data-target="#filterModal" class="ml-1">
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variation" t-value="'hollow'" />
+                            <t t-set="color" t-value="'low-black'" />
+                            <t t-set="icon_color" t-value="'low-black'" />
+                            <t t-set="variant" t-value="'compact'" />
+                            <t t-set="icon" t-value="'icon-filter-lines'" />
+                            <t t-set="text_color" t-value="'low-black'" />
+                            <t t-set="label" t-value="str(nr_filters_applied) + ' filters applied'" />
                         </t>
+                    </a>
+                </div>
+                <!-- Filter modal -->
+                <div
+                    class="modal fade"
+                    id="filterModal"
+                    tabindex="-1"
+                    role="dialog"
+                    aria-labelledby="filterModalLabel"
+                    aria-hidden="true"
+                >
+                    <div class="modal-dialog modal-sm" role="document">
+                        <div class="modal-content border-0">
+                            <div class="text-center p-0 m-0">
+                                <h2 class="text-pure-white bg-low-blue pb-2 pt-3">Filter letters</h2>
+                                <!-- Filter form: date range -->
+                                <div class="pl-4 pr-4 pt-3">
+                                    <h3 class="text-low-blue">Children</h3>
+                                    <!-- Children dropdown -->
+                                    <div class="pb-2">
+                                        <t t-set="id" t-value="'childrenDropdown'" />
+                                        <t t-set="name" t-value="'child'" />
+                                        <t t-call="theme_compassion_2025.SelectComponent">
+                                            <option value="">Children</option>
+                                            <t t-foreach="children_list" t-as="child">
+                                                <option
+                                                    t-att-value="child.id"
+                                                    t-att-selected="'selected' if filter_child and filter_child.id == child.id else None"
+                                                >
+                                                    <t t-esc="child.preferred_name" />
+                                                </option>
+                                            </t>
+                                        </t>
+                                    </div>
+                                    <h3 class="text-low-blue">From</h3>
+                                    <div class="justify-content-between d-flex w-100 pb-2">
+                                        <!-- Month Dropdown (from)-->
+                                        <div class="w-60">
+                                            <t t-set="id" t-value="'monthDropdownFrom'" />
+                                            <t t-set="name" t-value="'month_from'" />
+                                            <t
+                                                t-set="months"
+                                                t-value="[
+        (1, 'January'), (2, 'February'), (3, 'March'), (4, 'April'),
+        (5, 'May'), (6, 'June'), (7, 'July'), (8, 'August'),
+        (9, 'September'), (10, 'October'), (11, 'November'), (12, 'December')
+    ]"
+                                            />
+                                            <t t-call="theme_compassion_2025.SelectComponent">
+                                                <option value="">Month</option>
+                                                <t t-foreach="months" t-as="month">
+                                                    <option
+                                                        t-att-value="month[0]"
+                                                        t-att-selected="'selected' if filters['month_from'] == month[0] else None"
+                                                    >
+                                                        <t t-esc="month[1]" />
+                                                    </option>
+                                                </t>
+                                            </t>
+                                        </div>
+                                        <!-- Year Dropdown (from) -->
+                                        <div class="w-30">
+                                            <t t-set="id" t-value="'yearDropdownFrom'" />
+                                            <t t-set="name" t-value="'year'" />
+                                            <t t-call="theme_compassion_2025.SelectComponent">
+                                                <option value="">Year</option>
+                                                <t t-foreach="range(current_year, 2015, -1)" t-as="year">
+                                                    <option
+                                                        t-att-value="year"
+                                                        t-att-selected="'selected' if filters['year_from'] == year else None"
+                                                    >
+                                                        <t t-esc="year" />
+                                                    </option>
+                                                </t>
+                                            </t>
+                                        </div>
+                                    </div>
+                                    <h3 class="text-low-blue">To</h3>
+                                    <div class="justify-content-between d-flex w-100 pb-4">
+                                        <!-- Month Dropdown (to)-->
+                                        <div class="w-60">
+                                            <t t-set="id" t-value="'monthDropdownTo'" />
+                                            <t t-set="name" t-value="'month'" />
+                                            <t
+                                                t-set="months"
+                                                t-value="[
+        (1, 'January'), (2, 'February'), (3, 'March'), (4, 'April'),
+        (5, 'May'), (6, 'June'), (7, 'July'), (8, 'August'),
+        (9, 'September'), (10, 'October'), (11, 'November'), (12, 'December')
+    ]"
+                                            />
+                                            <t t-call="theme_compassion_2025.SelectComponent">
+                                                <option value="">Month</option>
+                                                <t t-foreach="months" t-as="month">
+                                                    <option
+                                                        t-att-value="month[0]"
+                                                        t-att-selected="'selected' if filters['month_to'] == month[0] else None"
+                                                    >
+                                                        <t t-esc="month[1]" />
+                                                    </option>
+                                                </t>
+                                            </t>
+                                        </div>
+                                        <!-- Year Dropdown (to) -->
+                                        <div class="w-30">
+                                            <t t-set="id" t-value="'yearDropdownTo'" />
+                                            <t t-set="name" t-value="'year'" />
+                                            <t t-call="theme_compassion_2025.SelectComponent">
+                                                <option value="">Year</option>
+                                                <t t-foreach="range(current_year, 2015, -1)" t-as="year">
+                                                    <option
+                                                        t-att-value="year"
+                                                        t-att-selected="'selected' if filters['year_to'] == year else None"
+                                                    >
+                                                        <t t-esc="year" />
+                                                    </option>
+                                                </t>
+                                            </t>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- Filter type and sort options -->
+                                <div class="pl-5 pr-5 pb-5 pt-3">
+                                    <!-- Type filter: Received / Sent -->
+                                    <div
+                                        class="btn-group btn-group-toggle justify-content-between d-flex w-100 pb-3"
+                                        data-toggle="buttons"
+                                        id="filterTypeToggle"
+                                    >
+                                        <label
+                                            t-att-class="'btn btn-secondary btn-custom-toggle text-low-blue bg-pure-white border-low-blue border-left-pill w-50' + (' active' if filters['type'] == 'Beneficiary To Supporter' else '')"
+                                        >
+                                            <input
+                                                type="radio"
+                                                name="type"
+                                                value="Beneficiary To Supporter"
+                                                t-att-checked="'checked' if filters['type'] == 'Beneficiary To Supporter' else None"
+                                            />
+                                            Received
+                                        </label>
+                                        <label
+                                            t-att-class="'btn btn-secondary btn-custom-toggle text-low-blue bg-pure-white border-low-blue border-right-pill w-50' + (' active' if filters['type'] == 'Supporter To Beneficiary' else '')"
+                                        >
+                                            <input
+                                                type="radio"
+                                                name="type"
+                                                value="Supporter To Beneficiary"
+                                                t-att-checked="'checked' if filters['type'] == 'Supporter To Beneficiary' else None"
+                                            />
+                                            Sent
+                                        </label>
+                                    </div>
+                                    <!-- Sort order: Newest / Oldest -->
+                                    <div
+                                        class="btn-group btn-group-toggle justify-content-between d-flex w-100 pb-3"
+                                        data-toggle="buttons"
+                                        id="sortToggle"
+                                    >
+                                        <label
+                                            t-att-class="'btn btn-secondary btn-custom-toggle text-low-blue bg-pure-white border-low-blue border-left-pill w-50' + (' active' if filters['sort'] == 'newest' else '')"
+                                        >
+                                            <input
+                                                type="radio"
+                                                name="sortOptions"
+                                                value="newest"
+                                                t-att-checked="'checked' if filters['sort'] == 'newest' else None"
+                                            />
+                                            Newest
+                                        </label>
+                                        <label
+                                            t-att-class="'btn btn-secondary btn-custom-toggle text-low-blue bg-pure-white border-low-blue border-right-pill w-50' + (' active' if filters['sort'] == 'oldest' else '')"
+                                        >
+                                            <input
+                                                type="radio"
+                                                name="sortOptions"
+                                                value="oldest"
+                                                t-att-checked="'checked' if filters['sort'] == 'oldest' else None"
+                                            />
+                                            Oldest
+                                        </label>
+                                    </div>
+                                    <!-- Ok and cancel filter actions -->
+                                    <div class="d-flex w-100 justify-content-between">
+                                        <a id="filterOkBtn" data-dismiss="modal">
+                                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                                                <t t-set="variation" t-value="'filled'" />
+                                                <t t-set="color" t-value="'mid-green'" />
+                                                <t t-set="text_color" t-value="'pure-white'" />
+                                                <t t-set="variant" t-value="'compact'" />
+                                                <t t-set="label" t-value="'Ok'" />
+                                            </t>
+                                        </a>
+                                        <a t-att-href="'/my2/children/letters'">
+                                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                                                <t t-set="variation" t-value="'filled'" />
+                                                <t t-set="color" t-value="'low-orange'" />
+                                                <t t-set="text_color" t-value="'pure-white'" />
+                                                <t t-set="variant" t-value="'compact'" />
+                                                <t t-set="label" t-value="'Cancel'" />
+                                            </t>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <!-- Filters -->
-                <div class="row mb-3">
-                    <div class="col-6 text-center">
-                        <button type="button" class="btn-compassion btn-compassion-white">
-                            <span>Filter From</span>
-                        </button>
-                    </div>
-                    <div class="col-6 text-center">
-                        <button type="button" class="btn-compassion btn-compassion-white">
-                            <span>Filter To</span>
-                        </button>
-                    </div>
-                </div>
-                <!-- Letters -->
-                <t t-foreach="letters" t-as="letter">
-                    <div class="row">
-                        <!-- Using letter_card component -->
+            </div>
+            <!-- Letters -->
+            <div id="lettersContainer" class="row mb-3">
+                <t t-foreach="letter_children_pairs" t-as="pair" t-foreach-index="i">
+                    <t t-set="letter" t-value="pair[0]" />
+                    <t t-set="child" t-value="pair[1]" />
+                    <div
+                        class="col-12 col-md-6 col-lg-4 mb-3 mt-3 letter-card"
+                        t-att-data-create_date="letter.create_date"
+                        t-att-data-type="letter.direction"
+                        t-att-data-index="i"
+                    >
                         <t t-call="my_compassion.my2_letter_card_component">
-                            <!-- The data we are passing to the letter_card_component -->
                             <t t-set="letter" t-value="letter" />
+                            <t t-set="child" t-value="child" />
                         </t>
                     </div>
                 </t>
             </div>
+            <!-- Buttons for changing page -->
+            <div class="d-flex justify-content-center align-items-center mb-5">
+                <!-- Prev -->
+                <t t-if="current_page > 1">
+                    <a id="prevPageBtn">
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variation" t-value="'hollow'" />
+                            <t t-set="color" t-value="'mid-blue'" />
+                            <t t-set="text_color" t-value="'low-black'" />
+                            <t t-set="variant" t-value="'compact'" />
+                            <t t-set="label" t-value="'Prev'" />
+                        </t>
+                    </a>
+                </t>
+                <!-- Page indicator -->
+                <span id="pageIndicator" class="p-2">
+                    Page
+                    <t t-esc="current_page" />
+                    of
+                    <t t-esc="total_pages" />
+                </span>
+                <!-- Next -->
+                <t t-if="current_page &lt; total_pages">
+                    <a id="nextPageBtn">
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variation" t-value="'hollow'" />
+                            <t t-set="color" t-value="'mid-blue'" />
+                            <t t-set="text_color" t-value="'low-black'" />
+                            <t t-set="variant" t-value="'compact'" />
+                            <t t-set="label" t-value="'Next'" />
+                        </t>
+                    </a>
+                </t>
+                <t t-else="">
+                    <span class="disabled ps-3">Next</span>
+                </t>
+            </div>
         </t>
+        <!-- JavaScript logic for filter and sort -->
+        <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
     </template>
 </odoo>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -45,6 +45,10 @@
                                     <t t-set="label" t-value="'Write a letter'" />
                                     <t t-set="color" t-value="'core-blue'" />
                                     <t t-set="text_color" t-value="'core-blue'" />
+                                    <t
+                                        t-set="href"
+                                        t-value="'/my2/children/' + str(compassion_child.id) + '/letter/new'"
+                                    />
                                 </t>
                                 <t t-call="theme_compassion_2025.ThemedButtonComponent">
                                     <t t-set="variant" t-value="'compact'" />

--- a/theme_compassion_2025/static/src/scss/base/_borders.scss
+++ b/theme_compassion_2025/static/src/scss/base/_borders.scss
@@ -23,3 +23,11 @@
 .border-5 {
     border-width: 5px !important;
 }
+
+.rounded-4 {
+  border-radius: 0.75rem !important;
+}
+
+.rounded-5 {
+  border-radius: 1rem !important;
+}

--- a/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
+++ b/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
@@ -55,7 +55,6 @@
                 t-att-href="href"
                 t-att-id="id"
                 t-attf-class="btn btn--#{variant}-#{variation} #{style_class} text-#{text_color}"
-                role="button"
             >
                 <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
             </a>

--- a/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
+++ b/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
@@ -24,8 +24,21 @@
     - icon_color (string): Color of the icon
     - text_color (string): Color of the text
     - id (string, optional): The ID to be assigned to the button element.
+    - href (string, optional): The URL to link to. If provided, an 'a' tag will be rendered instead of a 'button'.
 -->
 <odoo>
+    <template id="ThemedButtonComponent_Content" name="Button Content">
+        <t t-if="icon">
+            <span t-attf-class="btn__icon btn__icon--#{variant} text-#{icon_color}">
+                <i t-att-class="icon" />
+            </span>
+        </t>
+        <t t-if="label">
+            <span>
+                <t t-esc="label" />
+            </span>
+        </t>
+    </template>
     <template id="ThemedButtonComponent" name="Button Component">
         <!-- Determine button style class border or background depending on the variation-->
         <t t-if="variation == 'hollow'">
@@ -37,17 +50,20 @@
         <t t-else="">
             <t t-set="style_class" t-value="'bg-black'" />
         </t>
-        <button t-att-id="id" t-attf-class="btn btn--#{variant}-#{variation} #{style_class} text-#{text_color}">
-            <t t-if="icon">
-                <span t-attf-class="btn__icon btn__icon--#{variant} text-#{icon_color}">
-                    <i t-att-class="icon" />
-                </span>
-            </t>
-            <t t-if="label">
-                <span>
-                    <t t-esc="label" />
-                </span>
-            </t>
-        </button>
+        <t t-if="href">
+            <a
+                t-att-href="href"
+                t-att-id="id"
+                t-attf-class="btn btn--#{variant}-#{variation} #{style_class} text-#{text_color}"
+                role="button"
+            >
+                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
+            </a>
+        </t>
+        <t t-else="">
+            <button t-att-id="id" t-attf-class="btn btn--#{variant}-#{variation} #{style_class} text-#{text_color}">
+                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
+            </button>
+        </t>
     </template>
 </odoo>


### PR DESCRIPTION
Things added that were not present on figma:

-page changer (only 24 letters displayed per page)
-animation of the letter
-preview of the actual letter in the letter animation

Things i changed from the figma page (most were discussed with daniel):

-Took out the button with the picture of the children
-Added the children filter to the modal
-Button for sorting by newest/oldest redesigned a bit

Things worth mentioning:

-The page is accessible trough .../my2/children/letters or .../my2/children/letters/{children_id}. In the latter case the filter already includes the children that has the corresponding child_id. I think when accessing the letters page trough a children profile the url should be that, while when accessing trough another place the link should be .../my2/children/letters.
-The functionality of the buttons "share" and "reply" still have to be implemented
-Some letters don't open (especially the ones from the childrens)

[Screencast from 23.07.2025 13:23:28.webm](https://github.com/user-attachments/assets/5e86db95-2ed6-43d1-aceb-fb5b001f40cc)
[Screencast from 23.07.2025 17:00:30.webm](https://github.com/user-attachments/assets/0a778880-d259-4fab-b4c5-8a52e40ce370)
[Screencast from 24.07.2025 15:35:51.webm](https://github.com/user-attachments/assets/e2b44a51-d85d-4782-8ffc-7f167e6ee5f8)
