### PR TITLE
Fix trailing issues in scss files on themes (map-get and trailing comma missing)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,7 @@ repos:
         types: [text]
         files: \.(css|htm|html|js|json|jsx|less|md|scss|toml|ts|xml|yaml|yml)$
         language: node
+        exclude: \.scss$
         additional_dependencies:
           - "prettier@2.1.2"
           - "@prettier/plugin-xml@0.12.0"


### PR DESCRIPTION
Exclude scss files when prettier hook is launch to avoid trailing comma being removed and map-get failing to load palettes