### PR TITLE
T2602 Add already authenticated support to new sponsorship feature

### DIFF
--- a/my_compassion/__manifest__.py
+++ b/my_compassion/__manifest__.py
@@ -80,6 +80,8 @@
         "templates/components/my2_giving_limits_table.xml",
         "templates/components/my2_giving_limits_modal.xml",
         "templates/components/my2_checkout.xml",
+        # Other data the depends on the templates
+        "data/my2_new_sponsorship_wizard_steps.xml",
     ],
     "depends": [
         "partner_communication_compassion",

--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -173,20 +173,19 @@ class MyCompassionNewSponsorshipController(http.Controller):
             raise Gone()
 
         # Create new wizard
-        wizard = request.env["new.sponsorship.wizard"].create({})
-        wizard.child = child
+        wizard = request.env["new.sponsorship.wizard"].create(
+            {
+                "child_id": child.id,
+                "user_id": request.env.user.id,
+            }
+        )
 
-        # Fetch available salutations and countries
-        titles = request.env["res.partner.title"].search([])
-        countries = request.env["res.country"].search([])
-
-        context = {
-            "wizard": wizard,
-            "titles": titles,
-            "countries": countries,
-        }
-
-        return request.render("my_compassion.my2_new_sponsorship_wizard_page", context)
+        return request.render(
+            "my_compassion.my2_new_sponsorship_wizard_page",
+            {
+                "form_content_html": self._render_form_content(wizard),
+            },
+        )
 
     @http.route(
         "/my2/new-sponsorship/step",
@@ -207,39 +206,12 @@ class MyCompassionNewSponsorshipController(http.Controller):
         wizard = request.env["new.sponsorship.wizard"].sudo().browse(wizard_id)
 
         # Update the record
-        self._update_wizard(wizard, post)
+        wizard.update(post)
 
-        # Fetch available salutations, countries, payment methods,
-        # languages and lead sources
-        titles = request.env["res.partner.title"].search([])
-        countries = request.env["res.country"].search([])
-        spoken_languages = (
-            request.env["res.lang.compassion"]
-            .sudo()
-            .search([("translatable", "=", True)])
-        )
-        payment_methods = request.env["account.payment.mode"].sudo().search([])
-        lead_sources = request.env["recurring.contract.origin"].sudo().search([])
-
-        # TODO: decide if we filter by website_published or not
-        # payment_methods = request.env["account.payment.mode"].sudo().search([("website_published", "=", True)]) # noqa: E501
-        # lead_sources = request.env["recurring.contract.origin"].sudo().search([("website_published", "=", True)]) # noqa: E501
-
-        context = {
-            "wizard": wizard,
-            "titles": titles,
-            "countries": countries,
-            "payment_methods": payment_methods,
-            "spoken_languages": spoken_languages,
-            "lead_sources": lead_sources,
-        }
-
-        # Render and return the updated content
-        html_content = request.env["ir.qweb"]._render(
-            "my_compassion.my2_new_sponsorship_wizard_form_content", context
-        )
-
-        return {"html": html_content}
+        if wizard.is_done:
+            return {"finish": True}
+        else:
+            return {"html": self._render_form_content(wizard)}
 
     @http.route(
         "/my2/new-sponsorship/submit",
@@ -258,13 +230,10 @@ class MyCompassionNewSponsorshipController(http.Controller):
         wizard_id = int(post.get("wizard_id"))
         wizard = request.env["new.sponsorship.wizard"].sudo().browse(wizard_id)
 
-        # Update wizard
-        self._update_wizard(wizard, post)
-
         # Make sure child is still available and finalize sponsorship creation
-        if wizard.child.state not in wizard.child._available_states():
+        if wizard.child_id.state not in wizard.child_id._available_states():
             raise Gone()
-        sponsorship = wizard.action_finish_sponsorship()
+        sponsorship = wizard.finish_sponsorship()
 
         # Redirect to thank-you page
         return request.redirect(
@@ -286,57 +255,52 @@ class MyCompassionNewSponsorshipController(http.Controller):
         return request.render(
             "my_compassion.my2_new_sponsorship_thank_you_page",
             {
-                "n_steps": request.env["new.sponsorship.wizard"].n_steps,
+                "n_steps": 3,
                 "sponsorship": sponsorship,
             },
         )
 
     @staticmethod
-    def _update_wizard(wizard, post):
-        values = {}
+    def _render_form_content(wizard):
+        # Fetch available salutations, countries, payment methods,
+        # languages and lead sources
+        titles = request.env["res.partner.title"].search([])
+        countries = request.env["res.country"].search([])
+        spoken_languages = (
+            request.env["res.lang.compassion"]
+            .sudo()
+            .search([("translatable", "=", True)])
+        )
+        payment_methods = request.env["account.payment.mode"].sudo().search([])
+        lead_sources = request.env["recurring.contract.origin"].sudo().search([])
 
-        def soft_convert(value, convert=lambda x: x):
-            try:
-                return convert(value)
-            except (ValueError, TypeError):
-                return None
+        # TODO: decide if we filter by website_published or not
+        # payment_methods = request.env["account.payment.mode"].sudo().search([("website_published", "=", True)]) # noqa: E501
+        # lead_sources = request.env["recurring.contract.origin"].sudo().search([("website_published", "=", True)]) # noqa: E501
 
-        if wizard.step == 0:
-            values["title"] = soft_convert(post.get("title"), int)
-            values["lastname"] = post.get("lastname")
-            values["firstname"] = post.get("firstname")
-            values["birthdate"] = post.get("birthdate")
-            values["email"] = post.get("email")
-            values["phone"] = post.get("phone")
-            values["street"] = post.get("street")
-            values["street_number"] = post.get("street_number")
-            values["zip"] = post.get("zip")
-            values["city"] = post.get("city")
-            values["country"] = post.get("country")
+        # Render step template first
+        inner_step_html = request.env["ir.qweb"]._render(
+            wizard.current_step.template,
+            {
+                "wizard": wizard,
+                "titles": titles,
+                "countries": countries,
+                "payment_methods": payment_methods,
+                "spoken_languages": spoken_languages,
+                "lead_sources": lead_sources,
+            },
+        )
 
-        if wizard.step == 1:
-            values["payment_method"] = soft_convert(post.get("payment_method"), int)
-            values["sponsorship_plus"] = soft_convert(
-                post.get("sponsorship_plus"), bool
-            )
+        # Render and return the updated content
+        html_content = request.env["ir.qweb"]._render(
+            "my_compassion.my2_new_sponsorship_wizard_form_content",
+            {
+                "wizard": wizard,
+                "inner_step_html": inner_step_html,
+            },
+        )
 
-        if wizard.step == 2:
-            spoken_languages_ids = [
-                int(post.get(key)) for key in post if key.startswith("spoken_language")
-            ]
-            values["spoken_languages"] = [(6, 0, spoken_languages_ids)]
-            values["lead_source"] = soft_convert(post.get("lead_source"), int)
-            values["volunteering"] = soft_convert(post.get("volunteering"), bool)
-
-        wizard.write(values)
-
-        # Move to previous / next step
-        if "action" in post:
-            action = post.get("action")
-            if action == "next":
-                wizard.action_next_step()
-            elif action == "previous":
-                wizard.action_previous_step()
+        return html_content
 
     @staticmethod
     def _get_reservation_uuid():

--- a/my_compassion/data/my2_new_sponsorship_wizard_steps.xml
+++ b/my_compassion/data/my2_new_sponsorship_wizard_steps.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="new_sponsorship_wizard_step_user_details" model="new.sponsorship.wizard.step">
+            <field name="title">Your details</field>
+            <field name="template" ref="my_compassion.my2_new_sponsorship_wizard_user_details"/>
+        </record>
+        <record id="new_sponsorship_wizard_step_payment_methods" model="new.sponsorship.wizard.step">
+            <field name="title">Payment options</field>
+            <field name="template" ref="my_compassion.my2_new_sponsorship_wizard_payment_method"/>
+        </record>
+        <record id="new_sponsorship_wizard_step_communication_details" model="new.sponsorship.wizard.step">
+            <field name="title">Communication</field>
+            <field name="template" ref="my_compassion.my2_new_sponsorship_wizard_communication_details"/>
+        </record>
+    </data>
+</odoo>

--- a/my_compassion/models/my2_new_sponsorship_wizard.py
+++ b/my_compassion/models/my2_new_sponsorship_wizard.py
@@ -1,14 +1,45 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class NewSponsorshipWizard(models.TransientModel):
     _name = "new.sponsorship.wizard"
     _description = "New Sponsorship Wizard"
 
-    n_steps = 3
-    step = fields.Integer()
+    STEP_CONFIGS = {
+        "standard": {
+            "public": [
+                "my_compassion.new_sponsorship_wizard_step_user_details",
+                "my_compassion.new_sponsorship_wizard_step_payment_methods",
+            ],
+            "logged_in": [
+                "my_compassion.new_sponsorship_wizard_step_payment_methods",
+            ],
+        }
+    }
 
-    child = fields.Many2one("compassion.child")
+    current_step_idx = fields.Integer()
+    current_step = fields.Many2one(
+        "new.sponsorship.wizard.step",
+        compute="_compute_current_step",
+        readonly=True,
+    )
+    n_steps = fields.Integer(
+        compute="_compute_n_steps",
+        readonly=True,
+    )
+    is_done = fields.Boolean(
+        compute="_compute_is_done",
+        readonly=True,
+    )
+
+    user_id = fields.Many2one(
+        "res.users",
+        required=True,
+    )
+    child_id = fields.Many2one(
+        "compassion.child",
+        required=True,
+    )
 
     # User details fields
     title = fields.Many2one("res.partner.title")
@@ -43,45 +74,99 @@ class NewSponsorshipWizard(models.TransientModel):
     )
     volunteering = fields.Boolean()
 
-    def action_next_step(self):
-        self.ensure_one()
-        if self.step < (self.n_steps - 1):
-            self.step += 1
+    @api.depends("current_step_idx", "user_id")
+    def _compute_current_step(self):
+        for wizard in self:
+            steps = wizard._get_steps()
+            if 0 <= wizard.current_step_idx < len(steps):
+                wizard.current_step = steps[wizard.current_step_idx]
+            else:
+                wizard.current_step = False
 
-    def action_previous_step(self):
-        self.ensure_one()
-        if self.step > 0:
-            self.step -= 1
+    @api.depends("user_id")
+    def _compute_n_steps(self):
+        for wizard in self:
+            wizard.n_steps = len(wizard._get_steps())
 
-    def action_finish_sponsorship(self):
+    @api.depends("current_step_idx", "n_steps")
+    def _compute_is_done(self):
+        for wizard in self:
+            wizard.is_done = wizard.current_step_idx >= wizard.n_steps
+
+    def update(self, post):
+        values = {}
+
+        def update_field(field, key, convert=lambda x: x):
+            try:
+                values[field] = convert(post[key])
+            except (ValueError, TypeError, KeyError):
+                pass
+
+        update_field("title", "title", int)
+        update_field("lastname", "lastname")
+        update_field("firstname", "firstname")
+        update_field("birthdate", "birthdate")
+        update_field("email", "email")
+        update_field("phone", "phone")
+        update_field("street", "street")
+        update_field("street_number", "street_number")
+        update_field("zip", "zip")
+        update_field("city", "city")
+        update_field("country", "country")
+
+        update_field("payment_method", "payment_method", int)
+        update_field("sponsorship_plus", "sponsorship_plus", bool)
+
+        spoken_languages_ids = [
+            int(post.get(key)) for key in post if key.startswith("spoken_language")
+        ]
+        if spoken_languages_ids:
+            values["spoken_languages"] = [(6, 0, spoken_languages_ids)]
+        update_field("lead_source", "lead_source", int)
+        update_field("volunteering", "volunteering", bool)
+
+        self.write(values)
+
+        # Move to previous / next step
+        action = post.get("action")
+        if action == "next":
+            if self.current_step_idx <= self.n_steps:
+                self.current_step_idx += 1
+        elif action == "previous":
+            if self.current_step_idx > 0:
+                self.current_step_idx -= 1
+
+    def finish_sponsorship(self):
         self.ensure_one()
 
-        # Look for existing partner, create one if not found
-        partner_vals = {
-            "title": self.title.id,
-            "lastname": self.lastname,
-            "firstname": self.firstname,
-            "birthdate_date": self.birthdate,
-            "email": self.email,
-            "phone": self.phone,
-            "street": f"{self.street} {self.street_number}",
-            "zip": self.zip,
-            "city": self.city,
-            "country_id": self.country.id,
-            "spoken_lang_ids": [(4, lang.id) for lang in self.spoken_languages],
-            "interested_for_volunteering": self.volunteering,
-        }
-        partner = self.env["res.partner.match"].match_values_to_partner(
-            partner_vals, match_update=False, match_create=False
-        )
-        if not partner:
-            partner = self.env["res.partner"].create(partner_vals)
+        partner = self.user_id.partner_id
+        if self.user_id._is_public():
+            # Look for existing partner, create one if not found
+            partner_vals = {
+                "title": self.title.id,
+                "lastname": self.lastname,
+                "firstname": self.firstname,
+                "birthdate_date": self.birthdate,
+                "email": self.email,
+                "phone": self.phone,
+                "street": f"{self.street} {self.street_number}",
+                "zip": self.zip,
+                "city": self.city,
+                "country_id": self.country.id,
+                "spoken_lang_ids": [(4, lang.id) for lang in self.spoken_languages],
+                "interested_for_volunteering": self.volunteering,
+            }
+            partner = self.env["res.partner.match"].match_values_to_partner(
+                partner_vals, match_update=False, match_create=False
+            )
+            if not partner:
+                partner = self.env["res.partner"].create(partner_vals)
 
         # Create new sponsorship
         sponsorship = self.env["recurring.contract"].create(
             {
                 "partner_id": partner.id,
-                "child_id": self.child.id,
+                "child_id": self.child_id.id,
                 "payment_mode_id": self.payment_method.id,
                 "type": "S",
             }
@@ -97,3 +182,25 @@ class NewSponsorshipWizard(models.TransientModel):
 
         # Return the new sponsorship
         return sponsorship
+
+    def _get_steps(self):
+        xml_ids = self.STEP_CONFIGS["standard"][
+            "public" if self.user_id._is_public() else "logged_in"
+        ]
+        return [self.env.ref(xml_id).id for xml_id in xml_ids]
+
+
+class NewSponsorshipWizardStep(models.Model):
+    _name = "new.sponsorship.wizard.step"
+    _description = "New Sponsorship Wizard Step"
+
+    title = fields.Char()
+
+    template = fields.Many2one(
+        "ir.ui.view",
+        string="Qweb Template",
+        required=True,
+        domain=[
+            ("type", "=", "qweb"),
+        ],
+    )

--- a/my_compassion/security/ir.model.access.csv
+++ b/my_compassion/security/ir.model.access.csv
@@ -16,3 +16,4 @@ access_donation_impact_line_portal,donation.impact.line,model_donation_impact_li
 access_donation_info_line_portal,donation.info.line,model_donation_info_line,base.group_portal,1,0,0,0
 edit_donation_impact_line,donation.impact.line,model_donation_impact_line,base.group_user,1,1,1,1
 edit_donation_info_line,donation.info.line,model_donation_info_line,base.group_user,1,1,1,1
+access_new_sponsorship_wizard_step,access.new.sponsorship.wizard.step,model_new_sponsorship_wizard_step,,1,0,0,0

--- a/my_compassion/static/src/js/my2_new_sponsorship_wizard.js
+++ b/my_compassion/static/src/js/my2_new_sponsorship_wizard.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         publicWidget.registry.NewSponsorshipWizard = publicWidget.Widget.extend({
             selector: ".new-sponsorship-wizard-form",
             events: {
-                "click .btn-next, .btn-previous, .btn-finish": "_onStepClick",
+                "click .btn-next, .btn-previous": "_onStepClick",
             },
 
             /**
@@ -26,7 +26,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
             _onStepClick: function (ev) {
                 ev.preventDefault();
 
-                var action = $(ev.currentTarget).attr("name"); // 'next', 'previous' or finish
+                var action = $(ev.currentTarget).attr("name"); // 'next', 'previous'
 
                 // Don't validate when moving backwards
                 if (action !== "previous" && !this._validateForm()) {
@@ -35,12 +35,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
                 // Prevent double clicks
                 this.$(".btn").prop("disabled", true);
-
-                // Submit the form and return if action is finish
-                if (action === "finish") {
-                    $(".new-sponsorship-wizard-form").submit();
-                    return;
-                }
 
                 // Serialize form and add action
                 var formData = this.$el.serializeArray();
@@ -55,11 +49,15 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         function (data) {
                             // Replace the form's inner content with the new step's HTML
                             if (data.html) {
-                                $(".new-sponsorship-wizard-form-content").html(data.html);
-                                $("html, body").animate({ scrollTop: 0 }, "slow");
+                                this.$(".new-sponsorship-wizard-form-content").html(data.html);
+                                this.$("html, body").animate({ scrollTop: 0 }, "slow");
                             }
-                            // Re-enable buttons
-                            this.$(".btn").prop("disabled", false);
+                            if (data.finish) {
+                                this.$el.submit();
+                            } else {
+                                // Re-enable buttons
+                                this.$(".btn").prop("disabled", false);
+                            }
                         }.bind(this)
                     )
                     .guardedCatch(

--- a/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
+++ b/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
@@ -36,7 +36,9 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                 </t>
             </div>
             <!-- Steps -->
-            <div class="d-flex justify-content-between">
+            <t t-if="n_steps == 1" t-set="justify_content" t-value="'center'" />
+            <t t-else="" t-set="justify_content" t-value="'between'" />
+            <div t-attf-class="d-flex justify-content-#{justify_content}">
                 <t t-foreach="range(n_steps)" t-as="i">
                     <div class="step-marker-container">
                         <div
@@ -53,302 +55,299 @@ Page: My Compassion 2 New Sponsorship Wizard Page
             </div>
         </div>
     </template>
+    <!-- NEW SPONSORSHIP WIZARD USER DETAILS STEP -->
+    <template id="my2_new_sponsorship_wizard_user_details" name="New Sponsorship Wizard User Details Step">
+        <div class="mb-3 p-3 rounded-lg bg-light-blue tiny-text">
+            Already have an account?
+            <a
+                t-attf-href="/web/login?redirect=/my2/new-sponsorship/#{wizard.child_id.id}"
+                class="tiny-text bold text-core-blue"
+            >
+                Log in
+            </a>
+        </div>
+        <!-- Salutation -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Salutation'" />
+            <t t-set="input_id" t-value="'title'" />
+            <t t-call="theme_compassion_2025.SelectComponent">
+                <t t-set="name" t-value="'title'" />
+                <t t-set="id" t-value="'title'" />
+                <t t-set="required" t-value="True" />
+                <option value="">Please select</option>
+                <t t-foreach="titles" t-as="title">
+                    <option t-att-selected="title.id == wizard.title.id" t-att-value="title.id">
+                        <t t-esc="title.name" />
+                    </option>
+                </t>
+            </t>
+        </t>
+        <!-- Surname -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Surname'" />
+            <t t-set="input_id" t-value="'lastname'" />
+            <input id="lastname" type="text" name="lastname" t-att-value="wizard.lastname" required="" />
+        </t>
+        <!-- Firstname -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Firstname'" />
+            <t t-set="input_id" t-value="'firstname'" />
+            <input id="firstname" type="text" name="firstname" t-att-value="wizard.firstname" required="" />
+        </t>
+        <!-- Date of birth -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Date of birth'" />
+            <t t-set="input_id" t-value="'birthdate'" />
+            <input id="birthdate" type="date" name="birthdate" t-att-value="wizard.birthdate" required="" />
+        </t>
+        <!-- Email -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'E-mail'" />
+            <t t-set="input_id" t-value="'email'" />
+            <input id="email" type="email" name="email" t-att-value="wizard.email" required="" />
+        </t>
+        <!-- Phone -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Phone number'" />
+            <t t-set="input_id" t-value="'phone'" />
+            <input id="phone" type="tel" name="phone" t-att-value="wizard.phone" required="" />
+        </t>
+        <!-- Street -->
+        <div class="d-flex">
+            <div class="w-100 flex-grow-1">
+                <t t-call="theme_compassion_2025.FormFieldComponent">
+                    <t t-set="top_class" t-value="'my-3'" />
+                    <t t-set="label" t-value="'Street'" />
+                    <t t-set="input_id" t-value="'street'" />
+                    <input id="street" type="text" name="street" t-att-value="wizard.street" required="" />
+                </t>
+            </div>
+            <div class="flex-shrink-1 ml-4">
+                <t t-call="theme_compassion_2025.FormFieldComponent">
+                    <t t-set="top_class" t-value="'my-3'" />
+                    <t t-set="label" t-value="'N°'" />
+                    <t t-set="input_id" t-value="'street_number'" />
+                    <input
+                        id="street_number"
+                        type="text"
+                        name="street_number"
+                        t-att-value="wizard.street_number"
+                        required=""
+                    />
+                </t>
+            </div>
+        </div>
+        <!-- Locality -->
+        <div class="d-flex">
+            <div class="flex-shrink-1 mr-4">
+                <t t-call="theme_compassion_2025.FormFieldComponent">
+                    <t t-set="top_class" t-value="'my-3'" />
+                    <t t-set="label" t-value="'Code'" />
+                    <t t-set="input_id" t-value="'zip'" />
+                    <input id="zip" type="text" name="zip" t-att-value="wizard.zip" required="" />
+                </t>
+            </div>
+            <div class="w-100 flex-grow-1">
+                <t t-call="theme_compassion_2025.FormFieldComponent">
+                    <t t-set="top_class" t-value="'my-3'" />
+                    <t t-set="label" t-value="'Locality'" />
+                    <t t-set="input_id" t-value="'city'" />
+                    <input id="city" type="text" name="city" t-att-value="wizard.city" required="" />
+                </t>
+            </div>
+        </div>
+        <!-- Country -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Country'" />
+            <t t-set="input_id" t-value="'country'" />
+            <t t-call="theme_compassion_2025.SelectComponent">
+                <t t-set="name" t-value="'country'" />
+                <t t-set="id" t-value="'country'" />
+                <t t-set="required" t-value="True" />
+                <option value="">Please select</option>
+                <t t-foreach="countries" t-as="country">
+                    <option t-att-selected="country.id == wizard.country.id" t-att-value="country.id">
+                        <t t-esc="country.name" />
+                    </option>
+                </t>
+            </t>
+        </t>
+    </template>
+    <!-- NEW SPONSORSHIP WIZARD PAYMENT METHODS STEP -->
+    <template id="my2_new_sponsorship_wizard_payment_method" name="New Sponsorship Wizard Payment Methods Step">
+        <!-- Payment method -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Payment method'" />
+            <t t-set="input_id" t-value="'payment_method'" />
+            <t t-call="theme_compassion_2025.SelectComponent">
+                <t t-set="name" t-value="'payment_method'" />
+                <t t-set="id" t-value="'payment_method'" />
+                <t t-set="required" t-value="True" />
+                <option value="">Please select</option>
+                <t t-foreach="payment_methods" t-as="payment_method">
+                    <option
+                        t-att-selected="payment_method.id == wizard.payment_method.id"
+                        t-att-value="payment_method.id"
+                    >
+                        <t t-esc="payment_method.name" />
+                    </option>
+                </t>
+            </t>
+        </t>
+        <!-- Sponsorship plus -->
+        <input type="hidden" name="sponsorship_plus" value="" />
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Sponsorship plus'" />
+            <div class="d-flex align-items-center">
+                <input
+                    type="checkbox"
+                    id="sponsorship_plus"
+                    name="sponsorship_plus"
+                    class="flex-shrink-0"
+                    t-att-checked="wizard.sponsorship_plus"
+                />
+                <label class="ml-2 mb-0 body-small bold" t-att-for="'sponsorship_plus'">Yes</label>
+            </div>
+            <div class="mt-3 p-4 bg-high-eggshell rounded-lg body-small">
+                The "Plus" sponsorship includes the "basic" sponsorship of CHF 42.- and an additional gift of
+                CHF 8.- per month.
+                <br />
+                <br />
+                The CHF 8.- helps to fund urgent needs not covered by the sponsorship (e.g. natural disasters,
+                surgical procedures, malaria prevention, etc.).
+                <br />
+                <br />
+                This solidarity fund is in place
+                <span class="body-small bold">for all children</span>
+                supported through Compassion.
+            </div>
+        </t>
+    </template>
+    <!-- NEW SPONSORSHIP WIZARD COMMUNICATION DETAILS STEP -->
+    <template
+        id="my2_new_sponsorship_wizard_communication_details"
+        name="New Sponsorship Wizard Communication Details Step"
+    >
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Spoken languages'" />
+            <div>For correspondence with my godchild, I also understand the following languages:</div>
+            <t t-foreach="spoken_languages" t-as="language">
+                <div class="ml-2 mt-2 d-flex align-items-center">
+                    <input
+                        type="checkbox"
+                        t-att-value="language.id"
+                        class="flex-shrink-0"
+                        t-attf-name="spoken_language_#{language.id}"
+                        t-att-id="'language_' + str(language.id)"
+                        t-att-checked="language in wizard.spoken_languages"
+                    />
+                    <label class="ml-2 mb-0 body-small" t-att-for="'language_' + str(language.id)">
+                        <t t-esc="language.name" />
+                    </label>
+                </div>
+            </t>
+        </t>
+        <!-- Lead source -->
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'How did you hear about Compassion?'" />
+            <t t-set="input_id" t-value="'lead_source'" />
+            <t t-call="theme_compassion_2025.SelectComponent">
+                <t t-set="name" t-value="'lead_source'" />
+                <t t-set="id" t-value="'lead_source'" />
+                <t t-set="required" t-value="True" />
+                <option value="">Please select</option>
+                <t t-foreach="lead_sources" t-as="lead_source">
+                    <option t-att-selected="lead_source.id == wizard.lead_source.id" t-att-value="lead_source.id">
+                        <t t-esc="lead_source.name" />
+                    </option>
+                </t>
+            </t>
+        </t>
+        <!-- Volunteering -->
+        <input type="hidden" name="volunteering" value="" />
+        <t t-call="theme_compassion_2025.FormFieldComponent">
+            <t t-set="top_class" t-value="'my-3'" />
+            <t t-set="label" t-value="'Volunteering'" />
+            <div class="d-flex align-items-center">
+                <input
+                    type="checkbox"
+                    id="volunteering"
+                    name="volunteering"
+                    class="flex-shrink-0"
+                    t-att-checked="wizard.volunteering"
+                />
+                <label class="ml-3 mb-0 body-small bold" t-att-for="'volunteering'">
+                    I wish to volunteer my time (letter translations, events, prayer, ...).
+                    Please contact me.
+                </label>
+            </div>
+            <div class="mt-2 p-4 bg-high-eggshell rounded-lg body-small">
+                Do you want to inspire other people to sponsor a child?
+                Does the situation of children in need particularly touch you and you want to take action?
+                <br />
+                <br />
+                You can volunteer for Compassion and thereby place your talents at the service of the most
+                destitute children
+                on the planet.
+                <br />
+                <br />
+                Translations, stuffing envelopes, presence at events, being a spokesperson in
+                your church or running for the children.
+            </div>
+        </t>
+    </template>
     <!-- NEW SPONSORSHIP WIZARD FORM CONTENT -->
     <template id="my2_new_sponsorship_wizard_form_content" name="New Sponsorship Wizard Dynamic Content">
         <input type="hidden" name="wizard_id" t-att-value="wizard.id" />
         <!-- PROGRESS BAR -->
-        <div class="mt-3 mb-2 px-2 px-lg-0 pt-2 w-100">
+        <div t-if="wizard.n_steps > 1" class="mt-3 mb-2 px-2 px-lg-0 pt-2 w-100">
             <t t-call="my_compassion.NewSponsorshipStepProgressBar">
                 <t t-set="n_steps" t-value="wizard.n_steps" />
-                <t t-set="current_step" t-value="wizard.step" />
+                <t t-set="current_step" t-value="wizard.current_step_idx" />
             </t>
         </div>
         <!-- TITLE -->
         <div class="mx-5 mt-4">
             <t t-call="theme_compassion_2025.TitleComponent">
-                <t t-if="wizard.step == 0" t-set="title_content" t-value="'Your details'" />
-                <t t-elif="wizard.step == 1" t-set="title_content" t-value="'Payment options'" />
-                <t t-elif="wizard.step == 2" t-set="title_content" t-value="'Communication'" />
+                <t t-set="title_content" t-value="wizard.current_step.title" />
                 <t t-set="color" t-value="'core-blue'" />
                 <t t-set="show_underline" t-value="True" />
                 <t t-set="underline_color" t-value="'low-yellow'" />
                 <t
                     t-set="description"
-                    t-valuef="Let's set up your sponsorship and introduce you to #{wizard.child.preferred_name}."
+                    t-valuef="Let's set up your sponsorship and introduce you to #{wizard.child_id.preferred_name}."
                 />
             </t>
         </div>
         <div class="p-1 d-flex flex-column">
-            <!-- USER DETAILS -->
-            <t t-if="wizard.step == 0">
-                <!-- Salutation -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Salutation'" />
-                    <t t-set="input_id" t-value="'title'" />
-                    <t t-call="theme_compassion_2025.SelectComponent">
-                        <t t-set="name" t-value="'title'" />
-                        <t t-set="id" t-value="'title'" />
-                        <t t-set="required" t-value="True" />
-                        <option value="">Please select</option>
-                        <t t-foreach="titles" t-as="title">
-                            <option t-att-selected="title.id == wizard.title.id" t-att-value="title.id">
-                                <t t-esc="title.name" />
-                            </option>
-                        </t>
-                    </t>
-                </t>
-                <!-- Surname -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Surname'" />
-                    <t t-set="input_id" t-value="'lastname'" />
-                    <input id="lastname" type="text" name="lastname" t-att-value="wizard.lastname" required="" />
-                </t>
-                <!-- Firstname -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Firstname'" />
-                    <t t-set="input_id" t-value="'firstname'" />
-                    <input id="firstname" type="text" name="firstname" t-att-value="wizard.firstname" required="" />
-                </t>
-                <!-- Date of birth -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Date of birth'" />
-                    <t t-set="input_id" t-value="'birthdate'" />
-                    <input id="birthdate" type="date" name="birthdate" t-att-value="wizard.birthdate" required="" />
-                </t>
-                <!-- Email -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'E-mail'" />
-                    <t t-set="input_id" t-value="'email'" />
-                    <input id="email" type="email" name="email" t-att-value="wizard.email" required="" />
-                </t>
-                <!-- Phone -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Phone number'" />
-                    <t t-set="input_id" t-value="'phone'" />
-                    <input id="phone" type="tel" name="phone" t-att-value="wizard.phone" required="" />
-                </t>
-                <!-- Street -->
-                <div class="d-flex">
-                    <div class="w-100 flex-grow-1">
-                        <t t-call="theme_compassion_2025.FormFieldComponent">
-                            <t t-set="top_class" t-value="'my-3'" />
-                            <t t-set="label" t-value="'Street'" />
-                            <t t-set="input_id" t-value="'street'" />
-                            <input id="street" type="text" name="street" t-att-value="wizard.street" required="" />
-                        </t>
-                    </div>
-                    <div class="flex-shrink-1 ml-4">
-                        <t t-call="theme_compassion_2025.FormFieldComponent">
-                            <t t-set="top_class" t-value="'my-3'" />
-                            <t t-set="label" t-value="'N°'" />
-                            <t t-set="input_id" t-value="'street_number'" />
-                            <input
-                                id="street_number"
-                                type="text"
-                                name="street_number"
-                                t-att-value="wizard.street_number"
-                                required=""
-                            />
-                        </t>
-                    </div>
-                </div>
-                <!-- Locality -->
-                <div class="d-flex">
-                    <div class="flex-shrink-1 mr-4">
-                        <t t-call="theme_compassion_2025.FormFieldComponent">
-                            <t t-set="top_class" t-value="'my-3'" />
-                            <t t-set="label" t-value="'Code'" />
-                            <t t-set="input_id" t-value="'zip'" />
-                            <input id="zip" type="text" name="zip" t-att-value="wizard.zip" required="" />
-                        </t>
-                    </div>
-                    <div class="w-100 flex-grow-1">
-                        <t t-call="theme_compassion_2025.FormFieldComponent">
-                            <t t-set="top_class" t-value="'my-3'" />
-                            <t t-set="label" t-value="'Locality'" />
-                            <t t-set="input_id" t-value="'city'" />
-                            <input id="city" type="text" name="city" t-att-value="wizard.city" required="" />
-                        </t>
-                    </div>
-                </div>
-                <!-- Country -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Country'" />
-                    <t t-set="input_id" t-value="'country'" />
-                    <t t-call="theme_compassion_2025.SelectComponent">
-                        <t t-set="name" t-value="'country'" />
-                        <t t-set="id" t-value="'country'" />
-                        <t t-set="required" t-value="True" />
-                        <option value="">Please select</option>
-                        <t t-foreach="countries" t-as="country">
-                            <option t-att-selected="country.id == wizard.country.id" t-att-value="country.id">
-                                <t t-esc="country.name" />
-                            </option>
-                        </t>
-                    </t>
-                </t>
-            </t>
-            <!-- PAYMENT OPTIONS -->
-            <t t-if="wizard.step == 1">
-                <!-- Payment method -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Payment method'" />
-                    <t t-set="input_id" t-value="'payment_method'" />
-                    <t t-call="theme_compassion_2025.SelectComponent">
-                        <t t-set="name" t-value="'payment_method'" />
-                        <t t-set="id" t-value="'payment_method'" />
-                        <t t-set="required" t-value="True" />
-                        <option value="">Please select</option>
-                        <t t-foreach="payment_methods" t-as="payment_method">
-                            <option
-                                t-att-selected="payment_method.id == wizard.payment_method.id"
-                                t-att-value="payment_method.id"
-                            >
-                                <t t-esc="payment_method.name" />
-                            </option>
-                        </t>
-                    </t>
-                </t>
-                <!-- Sponsorship plus -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Sponsorship plus'" />
-                    <div class="d-flex align-items-center">
-                        <input
-                            type="checkbox"
-                            id="sponsorship_plus"
-                            name="sponsorship_plus"
-                            class="flex-shrink-0"
-                            t-att-checked="wizard.sponsorship_plus"
-                        />
-                        <label class="ml-2 mb-0 body-small bold" t-att-for="'sponsorship_plus'">Yes</label>
-                    </div>
-                    <div class="mt-3 p-4 bg-high-eggshell rounded-lg body-small">
-                        The "Plus" sponsorship includes the "basic" sponsorship of CHF 42.- and an additional gift of
-                        CHF 8.- per month.
-                        <br />
-                        <br />
-                        The CHF 8.- helps to fund urgent needs not covered by the sponsorship (e.g. natural disasters,
-                        surgical procedures, malaria prevention, etc.).
-                        <br />
-                        <br />
-                        This solidarity fund is in place
-                        <span class="body-small bold">for all children</span>
-                        supported through Compassion.
-                    </div>
-                </t>
-            </t>
-            <!-- COMMUNICATION -->
-            <t t-if="wizard.step == 2">
-                <!-- Spoken language -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Spoken languages'" />
-                    <div>For correspondence with my godchild, I also understand the following languages:</div>
-                    <t t-foreach="spoken_languages" t-as="language">
-                        <div class="ml-2 mt-2 d-flex align-items-center">
-                            <input
-                                type="checkbox"
-                                t-att-value="language.id"
-                                class="flex-shrink-0"
-                                t-attf-name="spoken_language_#{language.id}"
-                                t-att-id="'language_' + str(language.id)"
-                                t-att-checked="language in wizard.spoken_languages"
-                            />
-                            <label class="ml-2 mb-0 body-small" t-att-for="'language_' + str(language.id)">
-                                <t t-esc="language.name" />
-                            </label>
-                        </div>
-                    </t>
-                </t>
-                <!-- Lead source -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'How did you hear about Compassion?'" />
-                    <t t-set="input_id" t-value="'lead_source'" />
-                    <t t-call="theme_compassion_2025.SelectComponent">
-                        <t t-set="name" t-value="'lead_source'" />
-                        <t t-set="id" t-value="'lead_source'" />
-                        <t t-set="required" t-value="True" />
-                        <option value="">Please select</option>
-                        <t t-foreach="lead_sources" t-as="lead_source">
-                            <option
-                                t-att-selected="lead_source.id == wizard.lead_source.id"
-                                t-att-value="lead_source.id"
-                            >
-                                <t t-esc="lead_source.name" />
-                            </option>
-                        </t>
-                    </t>
-                </t>
-                <!-- Volunteering -->
-                <t t-call="theme_compassion_2025.FormFieldComponent">
-                    <t t-set="top_class" t-value="'my-3'" />
-                    <t t-set="label" t-value="'Volunteering'" />
-                    <div class="d-flex align-items-center">
-                        <input
-                            type="checkbox"
-                            id="volunteering"
-                            name="volunteering"
-                            class="flex-shrink-0"
-                            t-att-checked="wizard.volunteering"
-                        />
-                        <label class="ml-3 mb-0 body-small bold" t-att-for="'volunteering'">
-                            I wish to volunteer my time (letter translations, events, prayer, ...).
-                            Please contact me.
-                        </label>
-                    </div>
-                    <div class="mt-2 p-4 bg-high-eggshell rounded-lg body-small">
-                        Do you want to inspire other people to sponsor a child?
-                        Does the situation of children in need particularly touch you and you want to take action?
-                        <br />
-                        <br />
-                        You can volunteer for Compassion and thereby place your talents at the service of the most
-                        destitute children
-                        on the planet.
-                        <br />
-                        <br />
-                        Translations, stuffing envelopes, presence at events, being a spokesperson in
-                        your church or running for the children.
-                    </div>
-                </t>
-            </t>
+            <t t-raw="inner_step_html" />
             <!-- BUTTONS -->
-            <div
-                t-if="wizard.step == (wizard.n_steps-1)"
-                class="btn-finish my-3 d-flex justify-content-center"
-                name="finish"
-            >
+            <div class="btn-next my-3 d-flex justify-content-center" name="next">
                 <t t-call="theme_compassion_2025.ThemedButtonComponent">
                     <t t-set="variant" t-value="'compact'" />
                     <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label" t-value="'Finish'" />
+                    <t t-if="wizard.current_step_idx &lt; (wizard.n_steps-1)" t-set="label" t-value="'Continue'" />
+                    <t t-else="" t-set="label" t-value="'Finish'" />
                     <t t-set="color" t-value="'core-blue'" />
                     <t t-set="text_color" t-value="'pure-white'" />
                 </t>
             </div>
             <div
-                t-if="wizard.step &lt; (wizard.n_steps-1)"
-                class="btn-next my-3 d-flex justify-content-center"
-                name="next"
+                t-if="wizard.current_step_idx &gt; 0"
+                class="btn-previous mt-2 mb-3 d-flex justify-content-center"
+                name="previous"
             >
-                <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                    <t t-set="variant" t-value="'compact'" />
-                    <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label" t-value="'Continue'" />
-                    <t t-set="color" t-value="'core-blue'" />
-                    <t t-set="text_color" t-value="'pure-white'" />
-                </t>
-            </div>
-            <div t-if="wizard.step &gt; 0" class="btn-previous mt-2 mb-3 d-flex justify-content-center" name="previous">
                 <button class="back-button text-low-black body-small bold">Back</button>
             </div>
         </div>
@@ -362,10 +361,8 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                 <form class="new-sponsorship-wizard-form" action="/my2/new-sponsorship/submit" method="POST">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                     <div class="new-sponsorship-wizard-form-content">
-                        <!-- INITIAL WIZARD INSTANCE -->
-                        <t t-call="my_compassion.my2_new_sponsorship_wizard_form_content">
-                            <t t-set="wizard" t-value="wizard" />
-                        </t>
+                        <!-- INITIAL FORM CONTENT -->
+                        <t t-raw="form_content_html" />
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
To be reviewed and merged before #130 .

Skip user/communication details in sponsorship form for authenticated users, and allow users to log in at the start of the user details step.

The steps of the forms were abstracted to a new model to improve modularity and composability.

### Image

<img width="649" height="902" alt="image" src="https://github.com/user-attachments/assets/7ca266d5-98ec-47e4-875a-506e280eee3f" />
