### PR TITLE
T2526 event banner system

### DIFF
--- a/my_compassion/__manifest__.py
+++ b/my_compassion/__manifest__.py
@@ -51,6 +51,7 @@
         "templates/login_template.xml",
         "templates/signup.xml",
         "views/correspondence_template_view.xml",
+        "views/my2_event_banner_views.xml",
         "views/partner_compassion_view.xml",
         "views/product_view.xml",
         "data/signup_email_confirmation.xml",
@@ -94,6 +95,7 @@
         "website_crm_privacy_policy",  # OCA/website
         "auth_signup_verify_email",  # OCA/server-auth
         "queue_job",
+        "theme_compassion_2025",
     ],
     "demo": [],
     "installable": True,

--- a/my_compassion/controllers/__init__.py
+++ b/my_compassion/controllers/__init__.py
@@ -18,4 +18,5 @@ from . import (
     my2_user,
     my2_user_settings,
     my2_sponsorships,
+    my2_event_banner,
 )

--- a/my_compassion/controllers/my2_event_banner.py
+++ b/my_compassion/controllers/my2_event_banner.py
@@ -1,0 +1,69 @@
+##############################################################################
+#
+#    Copyright (C) 2025 Compassion CH (http://www.compassion.ch)
+#    @author: Elias Keller <ekeller@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import fields, http
+from odoo.http import request
+
+
+def _normalize_current_page_route(route: str) -> str:
+    if not route:
+        return "/"
+    route = route.split("?", 1)[0].split("#", 1)[0]
+    return route
+
+
+class MyCompassionEventBannerController(http.Controller):
+    @http.route("/my2/active-event-banners", type="json", auth="public", website=True)
+    def get_active_banner(self, current_page_route=None, limit=None, **kw):
+        current_page_route = _normalize_current_page_route(current_page_route)
+
+        # Get all active language codes to check for URL prefixes
+        lang_codes = [
+            lang[0] for lang in request.env["res.lang"].sudo().get_installed()
+        ]
+        path_parts = current_page_route.split("/")
+        possible_routes = [current_page_route]
+
+        # If the path starts with a language code (e.g., /fr/dashboard),
+        # also search for the path without the language prefix.
+        if len(path_parts) > 1 and path_parts[1] in lang_codes:
+            unprefixed_route = "/" + "/".join(path_parts[2:])
+            possible_routes.append(unprefixed_route)
+
+        now = fields.Datetime.now()
+        domain = [
+            ("is_active", "=", True),
+            ("start_date", "<=", now),
+            "|",
+            ("end_date", "=", False),
+            ("end_date", ">=", now),
+            # Match either the full path or the path without the lang prefix
+            ("target_route_ids.path", "in", possible_routes),
+        ]
+
+        banners = (
+            request.env["event.banner"]
+            .sudo()
+            .search(
+                domain,
+                order="start_date desc, id desc",
+                limit=limit or None,
+            )
+        )
+
+        rendered_banners = []
+
+        if not banners:
+            return rendered_banners
+
+        for banner in banners:
+            html = request.env["ir.ui.view"]._render_template(
+                "theme_compassion_2025.EventBannerComponent", {"banner": banner}
+            )
+            rendered_banners.append({"id": banner.id, "html": html})
+        return rendered_banners

--- a/my_compassion/models/__init__.py
+++ b/my_compassion/models/__init__.py
@@ -20,4 +20,6 @@ from . import (
     sale_order_line,
     my2_donation_info_line,
     my2_donation_impact_line,
+    my2_event_banner,
+    my2_website_route,
 )

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -1,0 +1,192 @@
+##############################################################################
+#
+#    Copyright (C) 2025 Compassion CH (http://www.compassion.ch)
+#    @author: Elias Keller <elias@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+from werkzeug.exceptions import NotFound
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.http import request, root
+
+
+class EventBanner(models.Model):
+    _name = "event.banner"
+    _description = "Event Banner"
+
+    title = fields.Char(
+        required=True,
+        translate=True,
+    )
+
+    description = fields.Text(
+        required=True,
+        translate=True,
+    )
+
+    text_color = fields.Many2one(
+        "theme.compassion.colors",
+        required=True,
+        default=lambda self: self._get_default_color_by_name("Low Black"),
+    )
+
+    start_date = fields.Datetime(
+        default=fields.Datetime.now,
+        required=True,
+    )
+
+    end_date = fields.Datetime(
+        required=True,
+    )
+
+    is_active = fields.Boolean(
+        string="Active",
+        default=True,
+    )
+
+    pictogram = fields.Many2one(
+        "theme.compassion.pictograms",
+        required=True,
+    )
+
+    pictogram_color = fields.Many2one(
+        "theme.compassion.colors",
+        required=True,
+        default=lambda self: self._get_default_color_by_name("Low Blue"),
+    )
+
+    background_color = fields.Many2one(
+        "theme.compassion.colors",
+        required=True,
+        default=lambda self: self._get_default_color_by_name("High Yellow"),
+    )
+
+    button_text = fields.Char(
+        default="Learn more",
+        required=True,
+        translate=True,
+    )
+
+    button_text_color = fields.Many2one(
+        "theme.compassion.colors",
+        required=True,
+        default=lambda self: self._get_default_color_by_name("Pure White"),
+    )
+
+    button_background_color = fields.Many2one(
+        "theme.compassion.colors",
+        required=True,
+        default=lambda self: self._get_default_color_by_name("Low Blue"),
+    )
+
+    close_icon_color = fields.Many2one(
+        "theme.compassion.colors",
+        required=True,
+        default=lambda self: self._get_default_color_by_name("Low Blue"),
+    )
+
+    button_action_url = fields.Char(
+        help="URL as button action. Leave empty for no button.",
+        placeholder="e.g., https://www.google.com/",
+        translate=True,
+    )
+
+    target_route_ids = fields.Many2many(
+        "my2.website.route",
+        string="Target Pages",
+        help="Select the pages where this banner should be visible.",
+    )
+
+    def name_get(self):
+        """
+        Generates the display name for the banners.
+        Format: ‘Banner Title’
+        """
+        result = []
+        for banner in self:
+            result.append((banner.id, banner.title))
+        return result
+
+    @api.model
+    def _get_default_color_by_name(self, color_name):
+        """ """
+        # Passe 'name' an, falls das Feld in 'theme.compassion.colors' anders heißt.
+        color_record = self.env["theme.compassion.colors"].search(
+            [("name", "=", color_name)], limit=1
+        )
+        return color_record.id if color_record else False
+
+    @api.constrains("start_date", "end_date")
+    def _check_dates(self):
+        """Ensures that the end date is not before the start date."""
+        for banner in self:
+            if (
+                banner.start_date
+                and banner.end_date
+                and banner.start_date > banner.end_date
+            ):
+                raise ValidationError(_("The end date must be after the start date."))
+
+    @api.constrains("button_action_url")
+    def _check_button_action_url(self):
+        """Ensures that the button action URL is valid if provided."""
+        allowed = {"http", "https"}
+        for banner in self:
+            action_url = (banner.button_action_url or "").strip()
+
+            if not action_url:
+                continue
+
+            parsed = urlparse(action_url)
+            # A URL is valid if it's a relative path (no scheme, no netloc)
+            # or an absolute URL with an allowed scheme and a domain.
+            is_relative = not parsed.scheme and not parsed.netloc and parsed.path
+
+            if is_relative:
+                try:
+                    # Check if the relative URL corresponds to a valid route
+                    routing_map = root.get_db_router(self.env.cr.dbname)
+                    environ = getattr(request, "httprequest", {}).environ or {
+                        "REQUEST_METHOD": "GET"
+                    }
+                    matcher = routing_map.bind_to_environ(environ)
+                    matcher.match(action_url, method="GET")
+                except NotFound as err:
+                    raise ValidationError(
+                        _(
+                            "The relative URL '{url}' does not match any existing page."
+                        ).format(url=action_url)
+                    ) from err
+            elif parsed.scheme in allowed and parsed.netloc:
+                # It's an absolute URL, let's check if it's reachable.
+                try:
+                    response = requests.head(
+                        action_url, timeout=5, allow_redirects=True
+                    )
+                    response.raise_for_status()
+                except requests.exceptions.RequestException as e:
+                    raise ValidationError(
+                        _(
+                            "The URL '{url}' could not be reached or is invalid. "
+                            "Please check the address. (Error: {error})"
+                        ).format(url=action_url, error=e)
+                    ) from e
+            else:
+                raise ValidationError(
+                    _(
+                        "Invalid button action URL. "
+                        "Please enter a valid relative path (e.g., /contact) "
+                        "or a full URL (e.g., https://example.com)."
+                    )
+                )

--- a/my_compassion/models/my2_website_route.py
+++ b/my_compassion/models/my2_website_route.py
@@ -1,0 +1,77 @@
+##############################################################################
+#
+#    Copyright (C) 2025 Compassion CH (http://www.compassion.ch)
+#    @author: Elias Keller <ekeller@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import api, fields, models
+from odoo.http import request, root
+
+
+class My2WebsiteRoute(models.Model):
+    _name = "my2.website.route"
+    _description = "My2 Website Route"
+    _rec_name = "path"  # use the 'path' field as the display name for this model.
+    _order = "path"
+
+    path = fields.Char(string="Route Path", required=True, index=True)
+
+    def name_get(self):
+        return [(r.id, r.path or "/") for r in self]
+
+    @api.model
+    def action_refresh_routes_and_reload_view(self):
+        """
+        Updates the routes and return a success notification to the client
+        """
+        self._update_routes()
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": "Success",
+                "message": "The list of available website routes has been updated.",
+                "type": "success",
+                "sticky": False,
+            },
+        }
+
+    @api.model
+    def _get_my2_routes(self):
+        """
+        Scans the routes starting with '/my2/' and returns a set of paths.
+        """
+        paths = set()
+        if not request or not getattr(request, "httprequest", None):
+            return list(paths)
+
+        router = root.get_db_router(self.env.cr.dbname)
+        for rule in router.iter_rules():
+            routing = getattr(rule.endpoint, "routing", {})
+            if routing.get("website") and routing.get("type") == "http":
+                if rule.rule.startswith("/my2/"):
+                    paths.add(rule.rule)
+        return sorted(list(paths))
+
+    @api.model
+    def _update_routes(self):
+        """
+        Synchronizes the routes in the database with the ones
+        discovered from the controllers.
+        """
+        current_routes_set = set(self._get_my2_routes())
+        if not current_routes_set:
+            return
+
+        existing_routes_set = set(self.search([]).mapped("path"))
+
+        new_paths = current_routes_set - existing_routes_set
+        obsolete_paths = existing_routes_set - current_routes_set
+
+        if new_paths:
+            self.create([{"path": p} for p in new_paths])
+
+        if obsolete_paths:
+            self.search([("path", "in", list(obsolete_paths))]).unlink()

--- a/my_compassion/security/ir.model.access.csv
+++ b/my_compassion/security/ir.model.access.csv
@@ -18,3 +18,6 @@ edit_donation_impact_line,donation.impact.line,model_donation_impact_line,base.g
 edit_donation_info_line,donation.info.line,model_donation_info_line,base.group_user,1,1,1,1
 read_child_school_subject_portal,Child school subject read access,child_compassion.model_child_school_subject,base.group_portal,1,0,0,0
 access_new_sponsorship_wizard_step,access.new.sponsorship.wizard.step,model_new_sponsorship_wizard_step,,1,0,0,0
+access_event_banner_manager,MyCompassion: Event Banner manager,my_compassion.model_event_banner,website.group_website_designer,1,1,1,1
+access_my_compassion_website_route_user,MyCompassion: My2 Website Route user,my_compassion.model_my2_website_route,base.group_user,1,1,1,1
+access_my_compassion_website_route_public,MyCompassion: My2 Website Route public,my_compassion.model_my2_website_route,base.group_public,1,0,0,0

--- a/my_compassion/views/my2_event_banner_views.xml
+++ b/my_compassion/views/my2_event_banner_views.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- List View -->
+    <record id="view_my2_compassion_event_banner_tree" model="ir.ui.view">
+        <field name="name">event.banner.tree</field>
+        <field name="model">event.banner</field>
+        <field name="arch" type="xml">
+            <tree string="Event Banners">
+                <field name="title" />
+                <field name="is_active" />
+                <field name="start_date" />
+                <field name="end_date" />
+                <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
+                <field name="button_action_url" />
+            </tree>
+        </field>
+    </record>
+    <record id="action_server_refresh_website_routes" model="ir.actions.server">
+        <field name="name">Refresh Website Routes</field>
+        <field name="model_id" ref="my_compassion.model_my2_website_route" />
+        <field name="state">code</field>
+        <field name="code">action = model.action_refresh_routes_and_reload_view()</field>
+    </record>
+    <!-- Form -->
+    <record id="view_my2_compassion_event_banner_form" model="ir.ui.view">
+        <field name="name">event.banner.form</field>
+        <field name="model">event.banner</field>
+        <field name="arch" type="xml">
+            <form string="Event Banner">
+                <sheet>
+                    <group string="Content">
+                        <group>
+                            <field name="title" />
+                            <field name="description" />
+                        </group>
+                        <group>
+                            <field name="pictogram" />
+                            <field name="button_text" />
+                        </group>
+                    </group>
+                    <group string="Appearance">
+                        <group>
+                            <field name="background_color" />
+                            <field name="text_color" />
+                            <field name="pictogram_color" />
+                        </group>
+                        <group>
+                            <field name="button_background_color" />
+                            <field name="button_text_color" />
+                            <field name="close_icon_color" />
+                        </group>
+                    </group>
+                    <group string="Configuration">
+                        <group>
+                            <field name="button_action_url" />
+                            <field name="is_active" />
+                        </group>
+                        <group>
+                            <field name="start_date" />
+                            <field name="end_date" />
+                        </group>
+                    </group>
+                    <group string="Target Pages">
+                        <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <!-- Custom Filter -->
+    <record id="view_my2_compassion_event_banner_search" model="ir.ui.view">
+        <field name="name">event.banner.search</field>
+        <field name="model">event.banner</field>
+        <field name="arch" type="xml">
+            <search string="Search Event Banners">
+                <field name="title" string="Banner Title" />
+                <separator />
+                <filter
+                    string="Currently Active Banners"
+                    name="currently_active"
+                    domain="[('is_active', '=', True),
+                                 ('start_date', '&lt;=', now),
+                                 '|',
+                                 ('end_date', '=', False),
+                                 ('end_date', '&gt;=', now)]"
+                />
+            </search>
+        </field>
+    </record>
+    <!-- Window action -->
+    <record id="action_my2_compassion_event_banner" model="ir.actions.act_window">
+        <field name="name">Event Banners</field>
+        <field name="res_model">event.banner</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_my2_compassion_event_banner_search" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Create a new event banner.</p>
+        </field>
+    </record>
+    <!-- Menu Item -->
+    <menuitem
+        id="menu_my2_compassion_event_banner"
+        name="Event Banners"
+        parent="website.menu_website_configuration"
+        action="action_my2_compassion_event_banner"
+        sequence="50"
+    />
+    <menuitem
+        id="menu_refresh_routes"
+        name="Refresh Website Routes"
+        parent="website.menu_website_global_configuration"
+        action="action_server_refresh_website_routes"
+    />
+</odoo>

--- a/theme_compassion_2025/__manifest__.py
+++ b/theme_compassion_2025/__manifest__.py
@@ -55,6 +55,7 @@
         "templates/components/Select.xml",
         "templates/components/FormField.xml",
         "templates/components/RangeInputLoading.xml",
+        "templates/components/EventBanner.xml",
         # Buttons
         "templates/components/buttons/ThemedButton.xml",
         "templates/components/buttons/ToggleButton.xml",

--- a/theme_compassion_2025/static/src/js/_event_banner.js
+++ b/theme_compassion_2025/static/src/js/_event_banner.js
@@ -1,0 +1,112 @@
+odoo.define("theme_compassion_2025.event_banner", function (require) {
+    "use strict";
+
+    /**
+     * Event Banner public widget
+     * --------------------------
+     * - Injects active event banners into the page (top of the first .container inside <main>)
+     * - Animates open/close with CSS-driven transitions
+     * - Persists _onClose in localStorage so a user won't see the same banner again
+     *
+     */
+
+    const publicWidget = require("web.public.widget");
+    const rpc = require("web.rpc");
+
+    publicWidget.registry.EventBanner = publicWidget.Widget.extend({
+        selector: "main",
+        events: {
+            "click .event-banner .action-close": "_onClose",
+        },
+
+        async start() {
+            await this._super(...arguments);
+            return this._loadAndRender();
+        },
+
+        async _loadAndRender() {
+            const items = await rpc.query({
+                route: "/my2/active-event-banners",
+                params: {
+                    current_page_route: window.location.pathname,
+                },
+            });
+
+            if (!items || !items.length) {
+                return;
+            }
+
+            const dismissedBanners = JSON.parse(localStorage.getItem("dismissedBanners") || "[]");
+            const $container = $("main .container").first();
+
+            items
+                .slice()
+                .reverse()
+                .forEach((item) => {
+                    if (!item || !item.html || dismissedBanners.includes(item.id)) {
+                        return;
+                    }
+                    const $banner = $(item.html);
+
+                    const $wrap = $('<div class="event-banner-wrap"></div>').append($banner);
+                    $container.prepend($wrap);
+                    const targetBannerHeight = $banner.outerHeight(true);
+
+                    this._openAnimation($wrap, targetBannerHeight);
+                });
+        },
+
+        _openAnimation($wrap, targetBannerHeight) {
+            requestAnimationFrame(() => {
+                $wrap.css("max-height", 0);
+                $wrap.addClass("is-displayed");
+                $wrap.css("max-height", targetBannerHeight + "px");
+
+                const onEnd = (e) => {
+                    const prop = e.originalEvent ? e.originalEvent.propertyName : e.propertyName;
+                    if (e.target !== $wrap[0] || prop !== "max-height") {
+                        return;
+                    }
+                    $wrap.off("transitionend", onEnd);
+                    $wrap.css("max-height", "none");
+                };
+
+                $wrap.on("transitionend", onEnd);
+            });
+        },
+
+        _dismiss(id) {
+            const key = "dismissedBanners";
+            const list = JSON.parse(localStorage.getItem(key) || "[]");
+            if (!list.includes(id)) {
+                list.push(id);
+                localStorage.setItem(key, JSON.stringify(list));
+            }
+        },
+
+        _onClose(ev) {
+            ev.preventDefault();
+            const $banner = $(ev.currentTarget).closest(".event-banner");
+            const $wrap = $banner.closest(".event-banner-wrap");
+            const id = $banner.data("id");
+
+            this._closeAnimation($wrap, $banner);
+            this._dismiss(id);
+        },
+
+        _closeAnimation($wrap, $banner) {
+            if ($wrap.css("max-height") === "none") {
+                $wrap.css("max-height", $banner.outerHeight(true) + "px");
+            }
+
+            requestAnimationFrame(() => {
+                $wrap
+                    .removeClass("is-displayed")
+                    .css("max-height", 0)
+                    .one("transitionend", () => $wrap.remove());
+            });
+        },
+    });
+
+    return publicWidget.registry.EventBanner;
+});

--- a/theme_compassion_2025/static/src/scss/components/_event_banner.scss
+++ b/theme_compassion_2025/static/src/scss/components/_event_banner.scss
@@ -1,0 +1,41 @@
+/**
+    * _event_banner.scss
+    * ============
+    * This file contains the styles for the EventBanner used in the Compassion website.
+    * It includes the animation to reveal the banner content smoothly.
+    */
+
+.event-banner-wrap {
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height .35s ease-out;
+}
+
+.event-banner {
+    opacity: 0;
+    transform: translateY(-20px);
+    transition: opacity .35s ease-out, transform .35s ease-out;
+    will-change: opacity, transform;
+}
+
+.event-banner-wrap.is-displayed .event-banner {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.action-close {
+    cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .event-banner-wrap {
+        transition: none;
+        max-height: none;
+   }
+
+    .event-banner {
+        transition: none;
+        opacity: 1;
+        transform: none;
+     }
+}

--- a/theme_compassion_2025/templates/components/EventBanner.xml
+++ b/theme_compassion_2025/templates/components/EventBanner.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Component: Event Banner Component
+    Description: Renders a responsive and dismissible event banner with pictogram,
+                 title, description, and optional action button. Supports both
+                 mobile and desktop layouts.
+
+    Props:
+    - id:                The unique ID of the banner.
+    - background_color:  Background color class.
+    - text_color:        Text color class for the banner content.
+    - close_icon_color:  Color class for the close (dismiss) icon.
+    - pictogram:         Name of the pictogram icon to display.
+    - pictogram_color:   Color class for the pictogram.
+    - title:             Banner title.
+    - description:       Banner body text.
+    - button_label:      Optional button label (default: 'Learn more').
+    - button_action_url: Optional URL for the action button.
+    - button_background_color: Background color of the action button.
+    - button_text_color:       Text color of the action button.
+-->
+<odoo>
+    <template id="EventBannerComponent" name="Event Banner Component">
+        <div
+            t-att-data-id="banner.id"
+            t-attf-class="event-banner bg-#{banner.background_color.class_name} text-#{banner.text_color.class_name} mt-3 px-3 py-3 px-md-5 rounded-lg"
+        >
+            <div class="row no-gutters align-items-center">
+                <!-- Mobile Close Button and Pictogram Centered -->
+                <div class="col-12 d-md-none mb-2">
+                    <div class="d-flex align-items-start">
+                        <i t-attf-class="invisible h3 mb-0" />
+                        <div class="flex-fill d-flex justify-content-center">
+                            <i
+                                t-attf-class="display-4 mb-0 #{banner.pictogram.class_name} text-#{banner.pictogram_color.class_name}"
+                            />
+                        </div>
+                        <i
+                            t-attf-class="action-close h3 mb-0 icon-x-circle text-#{banner.close_icon_color.class_name}"
+                        />
+                    </div>
+                </div>
+                <!-- Desktop Pictogram and Content -->
+                <div class="col-12 col-md-1 d-none d-md-flex align-items-center justify-content-center">
+                    <i
+                        t-attf-class="display-4 mb-0 #{banner.pictogram.class_name} text-#{banner.pictogram_color.class_name}"
+                    />
+                </div>
+                <div
+                    class="col-12 col-md-7 col-lg-8 col-xl-9 d-flex flex-column align-items-center text-center align-items-md-start text-md-left"
+                >
+                    <p class="h3 font-weight-bold mb-1 text-low-black">
+                        <t t-esc="banner.title" />
+                    </p>
+                    <p class="mb-0 text-low-black text-break">
+                        <t t-esc="banner.description" />
+                    </p>
+                </div>
+                <div
+                    class="col-12 col-md-4 col-lg-3 col-xl-2 d-flex justify-content-center align-items-center justify-content-md-end mt-3 mt-md-0"
+                >
+                    <t t-if="banner.button_action_url">
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variant" t-value="'default'" />
+                            <t t-set="variation" t-value="'filled'" />
+                            <t t-set="label" t-value="banner.button_text or 'Learn more'" />
+                            <t t-set="color" t-value="banner.button_background_color.class_name" />
+                            <t t-set="text_color" t-value="banner.button_text_color.class_name" />
+                            <t t-set="radius" t-value="'pill'" />
+                            <t t-set="href" t-value="banner.button_action_url" />
+                        </t>
+                    </t>
+                    <i
+                        t-attf-class="action-close h3 d-none d-md-inline mb-0 ml-2 icon-x-circle text-#{banner.close_icon_color.class_name}"
+                    />
+                </div>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/theme_compassion_2025/views/assets.xml
+++ b/theme_compassion_2025/views/assets.xml
@@ -61,6 +61,11 @@
             <link
                 rel="stylesheet"
                 type="text/scss"
+                href="/theme_compassion_2025/static/src/scss/components/_event_banner.scss"
+            />
+            <link
+                rel="stylesheet"
+                type="text/scss"
                 href="/theme_compassion_2025/static/src/scss/components/_thread.scss"
             />
             <link
@@ -90,6 +95,7 @@
             />
             <script type="text/javascript" src="/theme_compassion_2025/static/src/js/_password.js" />
             <script type="text/javascript" src="/theme_compassion_2025/static/src/js/_range_input.js" />
+            <script type="text/javascript" src="/theme_compassion_2025/static/src/js/_event_banner.js" />
             <link
                 rel="stylesheet"
                 type="text/scss"


### PR DESCRIPTION
# Event Banners for MyCompassion 2.0 ([T2526](https://erp.compassion.ch/web#action=521&active_id=901&cids=1&id=3118&menu_id=2029&model=project.task&view_type=form))

This PR introduces configurable **Event Banners** that can be targeted to specific My2 pages.

## Backend

* **Model: `my2_event_banner.py`**
  A new model lets Compassion employees configure banners. **Key fields:**

  * **Content:** titles, body text, etc.
  * **Appearance:** background color, text color, etc.
  * **Configuration:** `start_date`, `end_date`, `is_active`
  * **Placement:** Many2many to `my2.website.route` (choose which pages show the banner)
  * **Action URL:** `action_url` opened by the banner’s button (optional, so the banner can also serve as an information-only banner)

* **Routes source:** `my2_website_route.py`
  Routes are persisted to the DB. An Compassion employee is able to refresh the routes on button click. This action scans currently active My2 routes and updates the `my2.website.route` table. This enables selecting routes via a simple M2M picker.

* **Usability:**
  Added a predefined filter to quickly show **currently active** banners.

## Frontend

* **Loader:** `_event_banner.js` runs on every My2 page.
* **Data flow:** The script calls a backend controller that returns rendered banners active for the current page.
* **UX:** Because banners load after initial page render, a fade-in animation smooths the experience.

## Dismissal & Persistence

* Users can close a banner using the close icon.
* Dismissed banner IDs are stored in `localStorage` so the same banner will not be shown again for that user on that browser (unless they clear storage).

---

## Screenshots

**Mobile:**
<img width="523" height="1062" alt="image" src="https://github.com/user-attachments/assets/ba22799e-60a7-4ac8-ad2f-443292754662" />

**Desktop:**
<img width="2408" height="951" alt="image" src="https://github.com/user-attachments/assets/46060b70-82b7-4b4a-8917-ba1c8c1d7c08" />


