### PR TITLE
T2612 replace all chf by companys currency

### DIFF
--- a/my_compassion/__manifest__.py
+++ b/my_compassion/__manifest__.py
@@ -89,6 +89,7 @@
         "web",
         "website_child_protection",
         "website_sponsorship",
+        "gift_compassion",
         "auth_signup",
         "website_crm_privacy_policy",  # OCA/website
         "auth_signup_verify_email",  # OCA/server-auth

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -205,6 +205,7 @@ class MyCompassionDonationsController(http.Controller):
             "default_custom_amount": order_line.price_total,
             "limits": limits,
             "date": fields.Date.today(),
+            "currency_name": order.pricelist_id.currency_id.name,
         }
 
         if order_line.is_gift:
@@ -290,6 +291,7 @@ class MyCompassionDonationsController(http.Controller):
                 "products": products,
                 "sponsorships": sponsorships,
                 "limits": limits,
+                "currency_name": order.pricelist_id.currency_id.name,
             },
         )
 

--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -321,6 +321,7 @@ class MyCompassionNewSponsorshipController(http.Controller):
         )
         payment_methods = request.env["account.payment.mode"].sudo().search([])
         lead_sources = request.env["recurring.contract.origin"].sudo().search([])
+        currency_name = request.env.user.company_id.currency_id.name
 
         # TODO: decide if we filter by website_published or not
         # payment_methods = request.env["account.payment.mode"].sudo().search([("website_published", "=", True)]) # noqa: E501
@@ -336,6 +337,7 @@ class MyCompassionNewSponsorshipController(http.Controller):
                 "payment_methods": payment_methods,
                 "spoken_languages": spoken_languages,
                 "lead_sources": lead_sources,
+                "currency_name": currency_name,
             },
         )
 
@@ -345,6 +347,7 @@ class MyCompassionNewSponsorshipController(http.Controller):
             {
                 "wizard": wizard,
                 "inner_step_html": inner_step_html,
+                "currency_name": currency_name,
             },
         )
 

--- a/my_compassion/templates/components/my2_donation_form.xml
+++ b/my_compassion/templates/components/my2_donation_form.xml
@@ -122,7 +122,7 @@
                                     t-set="price"
                                     t-value="product.my_compassion_donation_quantity_low * product.list_price"
                                 />
-                                CHF
+                                <t t-esc="product.currency_id.name" />
                                 <t t-if="price % 1 == 0" t-esc="int(price)" />
                                 <t t-else="" t-esc="'{0:.2f}'.format(price)" />
                             </label>
@@ -141,7 +141,7 @@
                                     t-set="price"
                                     t-value="product.my_compassion_donation_quantity_medium * product.list_price"
                                 />
-                                CHF
+                                <t t-esc="product.currency_id.name" />
                                 <t t-if="price % 1 == 0" t-esc="int(price)" />
                                 <t t-else="" t-esc="'{0:.2f}'.format(price)" />
                             </label>
@@ -160,7 +160,7 @@
                                     t-set="price"
                                     t-value="product.my_compassion_donation_quantity_high * product.list_price"
                                 />
-                                CHF
+                                <t t-esc="product.currency_id.name" />
                                 <t t-if="price % 1 == 0" t-esc="int(price)" />
                                 <t t-else="" t-esc="'{0:.2f}'.format(price)" />
                             </label>
@@ -186,7 +186,7 @@
                         id="custom-amount"
                         type="text"
                         name="custom_amount"
-                        placeholder="CHF"
+                        t-att-placeholder="'Enter amount in %s' % product.currency_id.name"
                         class="form-control mt-2"
                         hidden=""
                         t-att-value="'{:g}'.format(default_custom_amount) if default_custom_amount else ''"

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -18,6 +18,7 @@
     - name (string): Item name.                                                              -required-
     - image (string): Item image src.                                                        -required-
     - price (float): Item price.                                                             -required-
+    - currency_name (str): Currency name                                                     -required-
     - primary_button (dict): Primary button with custom action (see Button).                 [none]
     - recipient (string): Item recipient.                                                    [none]
     - title_color (string): Color of the title.                                              [dark-blue]
@@ -93,7 +94,7 @@
                         <t t-set="button" t-value="primary_button" />
                     </t>
                     <div t-attf-class="text-#{price_color} ">
-                        CHF
+                        <t t-esc="currency_name" />
                         <t t-if="price % 1 == 0" t-set="price" t-value="'{0}.-'.format(int(price))" />
                         <t t-else="" t-set="price" t-value="'{0:.2f}'.format(price)" />
                         <t t-if="monthly" t-set="monthly" t-value="'/mo.'" />

--- a/my_compassion/templates/components/my2_donation_product.xml
+++ b/my_compassion/templates/components/my2_donation_product.xml
@@ -74,7 +74,7 @@
                     <div t-attf-class="body-small text-#{price_color} ">
                         From
                         <span class="body-small bold">
-                            CHF
+                            <t t-esc="currency_name" />
                             <t
                                 t-set="price"
                                 t-value="product.my_compassion_donation_quantity_low * product.list_price"

--- a/my_compassion/templates/components/my2_giving_limits_table.xml
+++ b/my_compassion/templates/components/my2_giving_limits_table.xml
@@ -58,7 +58,7 @@
                     <t
                         t-set="cells"
                         t-value="[
-                        'CHF {:g}'.format(limit.currency_id._convert(limit.min_amount, company.currency_id, company, date))
+                        '{} {:g}'.format(currency_name, limit.currency_id._convert(limit.min_amount, company.currency_id, company, date))
                         for limit in limits
                     ]"
                     />
@@ -69,7 +69,7 @@
                     <t
                         t-set="cells"
                         t-value="[
-                        'CHF {:g}'.format(limit.currency_id._convert(limit.max_amount, company.currency_id, company, date))
+                        '{} {:g}'.format(currency_name, limit.currency_id._convert(limit.max_amount, company.currency_id, company, date))
                         for limit in limits
                     ]"
                     />

--- a/my_compassion/templates/pages/my2_gift_package.xml
+++ b/my_compassion/templates/pages/my2_gift_package.xml
@@ -33,6 +33,7 @@
                 <t t-set="recipient_color" t-value="'low-green'" />
                 <t t-set="bg_color" t-value="'mid-eggshell'" />
                 <t t-set="price" t-value="line.price_total" />
+                <t t-set="currency_name" t-value="line.currency_id.name" />
                 <t
                     t-set="image"
                     t-valuef="/web/image/#{line.product_template_id._name}/#{line.product_template_id.id}/my_compassion_image"
@@ -80,6 +81,7 @@
                 <t t-set="recipient_color" t-value="'dark-blue'" />
                 <t t-set="bg_color" t-value="'light-blue'" />
                 <t t-set="price" t-value="line.price_total" />
+                <t t-set="currency_name" t-value="line.currency_id.name" />
                 <t t-set="monthly" t-value="True" />
                 <t
                     t-set="image"
@@ -126,7 +128,7 @@
             <div class="text-mid-green body-large bold">Total amount</div>
             <div class="text-dark-blue body-large bold">
                 <t t-set="amount" t-value="order.amount_total" />
-                CHF
+                <t t-esc="order.currency_id.name" />
                 <t t-if="amount % 1 == 0" t-esc="int(amount)" />
                 <t t-else="" t-esc="'{0:.2f}'.format(amount)" />
             </div>

--- a/my_compassion/templates/pages/my2_gifts_thank_you.xml
+++ b/my_compassion/templates/pages/my2_gifts_thank_you.xml
@@ -57,6 +57,7 @@ Page: My Compassion 2 Thank you Page
                                     <t t-set="recipient_color" t-value="'low-green'" />
                                     <t t-set="bg_color" t-value="'mid-eggshell'" />
                                     <t t-set="price" t-value="line.price_total" />
+                                    <t t-set="currency_name" t-value="line.currency_id.name" />
                                     <t
                                         t-set="image"
                                         t-valuef="/web/image/#{line.product_template_id._name}/#{line.product_template_id.id}/my_compassion_image"
@@ -83,6 +84,7 @@ Page: My Compassion 2 Thank you Page
                                     <t t-set="recipient_color" t-value="'dark-blue'" />
                                     <t t-set="bg_color" t-value="'light-blue'" />
                                     <t t-set="price" t-value="line.price_total" />
+                                    <t t-set="currency_name" t-value="line.currency_id.name" />
                                     <t t-set="monthly" t-value="True" />
                                     <t
                                         t-set="image"

--- a/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
+++ b/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
@@ -222,11 +222,16 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                 <label class="ml-2 mb-0 body-small bold" t-att-for="'sponsorship_plus'">Yes</label>
             </div>
             <div class="mt-3 p-4 bg-high-eggshell rounded-lg body-small">
-                The "Plus" sponsorship includes the "basic" sponsorship of CHF 42.- and an additional gift of
-                CHF 8.- per month.
+                The "Plus" sponsorship includes the "basic" sponsorship of
+                <t t-esc="currency_name" />
+                42.- and an additional gift of
+                <t t-esc="currency_name" />
+                8.- per month.
                 <br />
                 <br />
-                The CHF 8.- helps to fund urgent needs not covered by the sponsorship (e.g. natural disasters,
+                The
+                <t t-esc="currency_name" />
+                8.- helps to fund urgent needs not covered by the sponsorship (e.g. natural disasters,
                 surgical procedures, malaria prevention, etc.).
                 <br />
                 <br />
@@ -296,7 +301,7 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                                     class="suggested-amount"
                                 />
                                 <label class="mb-0 w-100" t-attf-for="suggested-#{amount['name']}">
-                                    CHF
+                                    <t t-esc="currency_name" />
                                     <t t-esc="amount['amount']" />
                                 </label>
                             </div>
@@ -331,7 +336,7 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                     <input
                         type="text"
                         name="custom_amount"
-                        placeholder="CHF"
+                        t-att-placeholder="currency_name"
                         class="form-control"
                         t-att-value="'{:g}'.format(wizard.wap_contribution_amount) if wizard.wap_contribution_amount else ''"
                         required=""
@@ -440,7 +445,7 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                         <div class="pt-5 p-4 d-flex flex-column justify-content-center">
                             <div class="text-center body-large">
                                 Write&amp;Pray sponsorships are only available for people under the age of 25.
-                                Would you like to become a sponsor for CHF 42.-/month?
+                                Would you like to become a sponsor for <t t-esc="currency_name" /> 42.-/month?
                             </div>
                             <div
                                 class="btn-next align-self-stretch mt-5 d-flex justify-content-center"


### PR DESCRIPTION
When an item is present i took that item's currency, while for the other cases i searched the currency of the company in the controller. Maybe in my2_new_sponsorship_wizard it would be better to also take the prices of the sponsorships from the database and not hard code them, if the prices may vary between currencies/companies.