### PR TITLE
Add custom amount limitation on donation (frontend)

### DIFF
--- a/my_compassion/__manifest__.py
+++ b/my_compassion/__manifest__.py
@@ -76,6 +76,7 @@
         "templates/components/my2_donation_item.xml",
         "templates/components/my2_donation_product.xml",
         "templates/components/my2_donation_form.xml",
+        "templates/components/my2_giving_limits_table.xml",
         "templates/components/my2_giving_limits_modal.xml",
     ],
     "depends": [

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -9,7 +9,7 @@
 
 from werkzeug.exceptions import BadRequest, NotFound
 
-from odoo import http
+from odoo import fields, http
 from odoo.http import request
 
 
@@ -28,13 +28,17 @@ class MyCompassionDonationsController(http.Controller):
         details page.
         """
         sponsorships = request.env.user.partner_id.sponsorship_ids
+        donation_limits = request.env["gift.threshold.settings"].sudo().search([])
+
+        context = {
+            "product": product,
+            "sponsorships": sponsorships,
+            "donation_limits": donation_limits,
+        }
 
         return request.render(
             "my_compassion.my2_donation_details_page",
-            {
-                "product": product,
-                "sponsorships": sponsorships,
-            },
+            context,
         )
 
     @http.route(
@@ -109,6 +113,37 @@ class MyCompassionDonationsController(http.Controller):
         )
 
     @http.route(
+        "/my2/gifts/get-limits",
+        type="json",
+        auth="user",
+        website=True,
+        methods=["POST"],
+    )
+    def donation_get_limits(self, product_id, sponsorship_id=None, **post):
+        """
+        Returns the donation limits for a product (and optionally a sponsorship)
+        in the form:
+        {
+            "min_amount": int,               # If amount is limited
+            "max_amount": int,               # If amount is limited
+            "remaining_donations": int,      # If frequency is limited
+        }
+        """
+        product = request.env["product.template"].search([("id", "=", product_id)])
+        if not product:
+            return BadRequest()
+        if sponsorship_id is not None:
+            try:
+                sponsorship_id = int(sponsorship_id)
+            except TypeError as e:
+                raise BadRequest() from e
+
+        limits = product.get_donation_limits(
+            request.website.company_id, request.env.user.partner_id, sponsorship_id
+        )
+        return limits
+
+    @http.route(
         "/my2/gift-package",
         type="http",
         auth="user",
@@ -154,12 +189,16 @@ class MyCompassionDonationsController(http.Controller):
         if not order_line:
             raise NotFound()
 
+        limits = request.env["gift.threshold.settings"].sudo().search([])
+
         render_attrs = {
             "product": order_line.product_template_id,
             "submit_label": "Ok",
             "default_frequency": order_line.frequency,
             "default_suggested_amount": "custom",
             "default_custom_amount": order_line.price_total,
+            "limits": limits,
+            "date": fields.Date.today(),
         }
 
         if order_line.is_gift:

--- a/my_compassion/models/product_template.py
+++ b/my_compassion/models/product_template.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from odoo import fields, models
 
 
@@ -197,7 +195,9 @@ class ProductTemplate(models.Model):
                     first_january_of_this_year = fields.Date.today().replace(
                         day=1, month=1
                     )
-                    next_year = first_january_of_this_year + timedelta(days=365)
+                    next_year = first_january_of_this_year.replace(
+                        year=first_january_of_this_year.year + 1
+                    )
                     domain += [
                         ("gift_date", ">=", first_january_of_this_year),
                         ("gift_date", "<", next_year),

--- a/my_compassion/models/product_template.py
+++ b/my_compassion/models/product_template.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from odoo import fields, models
 
 
@@ -147,3 +149,84 @@ class ProductTemplate(models.Model):
     my_compassion_donation_quantity_high = fields.Integer(
         default=5, help="Highest quantity suggestion when making a donation"
     )
+
+    def get_donation_limits(self, company, partner, sponsorship_id=None):
+        """
+        Returns the donation limits for the product (optionally tied to a sponsorship)
+        in the form:
+        {
+            "min_amount": int,               # If amount is limited
+            "max_amount": int,               # If amount is limited
+            "remaining_donations": int,      # If frequency is limited
+        }
+        """
+        limits = {}
+        product_limits = (
+            self.env["gift.threshold.settings"]
+            .sudo()
+            .search([("product_id", "=", self.id)], limit=1)
+        )
+        if product_limits:
+            limits["min_amount"] = product_limits.currency_id._convert(
+                product_limits.min_amount,
+                company.currency_id,
+                company,
+                fields.Date.today(),
+            )
+            limits["max_amount"] = product_limits.currency_id._convert(
+                product_limits.max_amount,
+                company.currency_id,
+                company,
+                fields.Date.today(),
+            )
+
+            if product_limits.gift_frequency:
+                gift_types = self.env["sponsorship.gift"].get_gift_types(self)
+
+                domain = [
+                    ("partner_id", "=", partner.id),
+                    ("gift_type", "=", gift_types["gift_type"]),
+                    ("attribution", "=", gift_types["attribution"]),
+                    ("sponsorship_gift_type", "=", gift_types["sponsorship_gift_type"]),
+                ]
+
+                if sponsorship_id:
+                    domain += [("sponsorship_id", "=", sponsorship_id)]
+
+                if product_limits.yearly_threshold:
+                    first_january_of_this_year = fields.Date.today().replace(
+                        day=1, month=1
+                    )
+                    next_year = first_january_of_this_year + timedelta(days=365)
+                    domain += [
+                        ("gift_date", ">=", first_january_of_this_year),
+                        ("gift_date", "<", next_year),
+                    ]
+
+                other_gifts_count = (
+                    self.env["sponsorship.gift"].sudo().search_count(domain)
+                )
+                # Add gifts currently in the user's cart
+                sale_order = (
+                    self.env["sale.order"]
+                    .sudo()
+                    .search(
+                        [
+                            ("partner_id", "=", partner.id),
+                            ("state", "in", ["draft", "sent"]),
+                        ]
+                    )
+                )
+                order_lines = sale_order.order_line.filtered(
+                    lambda line: line.product_template_id.id == self.id
+                    and (
+                        (not sponsorship_id)
+                        or line.gift_recipient_id.id == sponsorship_id
+                    )
+                )
+                other_gifts_count += len(order_lines)
+                limits["remaining_donations"] = (
+                    product_limits.gift_frequency - other_gifts_count
+                )
+
+        return limits

--- a/my_compassion/static/src/css/my2_donation_form.css
+++ b/my_compassion/static/src/css/my2_donation_form.css
@@ -20,4 +20,15 @@
 
 .donation-inputs-container {
     max-width: 365px;
+
+    .limits-toggle {
+        cursor: pointer;
+        text-decoration: underline;
+    }
+
+    .limits-info {
+        a {
+            text-decoration: underline;
+        }
+    }
 }

--- a/my_compassion/static/src/css/my2_giving_limits_modal.css
+++ b/my_compassion/static/src/css/my2_giving_limits_modal.css
@@ -8,44 +8,6 @@
         }
     }
 
-    .table-title {
-        border-top-left-radius: 10px;
-        border-top-right-radius: 10px;
-    }
-
-    .table-column {
-        &:first-child {
-            .table-cell {
-                border-left: 1px solid var(--light-grey);
-
-                &:last-child {
-                    border-bottom-left-radius: 10px;
-                }
-            }
-        }
-
-        &:last-child {
-            .table-cell {
-                border-right: 1px solid var(--light-grey);
-
-                &:last-child {
-                    border-bottom-right-radius: 10px;
-                }
-            }
-        }
-    }
-
-    .table-cell {
-        height: 2.2rem;
-        padding-left: 1rem;
-        padding-right: 1rem;
-        border-bottom: 1px solid var(--light-grey);
-    }
-
-    .super-tiny-text {
-        font-size: 12px;
-    }
-
     a {
         text-decoration: underline;
     }

--- a/my_compassion/static/src/css/my2_giving_limits_table.css
+++ b/my_compassion/static/src/css/my2_giving_limits_table.css
@@ -1,0 +1,39 @@
+.giving-limits-table {
+    .table-title {
+        border-top-left-radius: 10px;
+        border-top-right-radius: 10px;
+    }
+
+    .table-column {
+        &:first-child {
+            .table-cell {
+                border-left: 1px solid var(--light-grey);
+
+                &:last-child {
+                    border-bottom-left-radius: 10px;
+                }
+            }
+        }
+
+        &:last-child {
+            .table-cell {
+                border-right: 1px solid var(--light-grey);
+
+                &:last-child {
+                    border-bottom-right-radius: 10px;
+                }
+            }
+        }
+    }
+
+    .table-cell {
+        height: 2.2rem;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        border-bottom: 1px solid var(--light-grey);
+    }
+
+    .super-tiny-text {
+        font-size: 12px;
+    }
+}

--- a/my_compassion/static/src/js/my2_donation_form.js
+++ b/my_compassion/static/src/js/my2_donation_form.js
@@ -127,12 +127,11 @@ odoo.define("my_compassion.donation_form", function (require) {
                         // Compute amount
                         const suggested_amount = this.$(".suggested-amount:checked").val();
                         const custom_amount = this.$("[name='custom_amount']").val();
-                        var amount = suggested_amount;
+                        let amount = suggested_amount;
                         if (amount === "custom") {
                             amount = custom_amount;
                         }
 
-                        console.log(data.remaining_donations);
                         if (
                             (data.min_amount !== null && amount < data.min_amount) ||
                             (data.max_amount !== null && amount > data.max_amount) ||

--- a/my_compassion/static/src/js/my2_donation_form.js
+++ b/my_compassion/static/src/js/my2_donation_form.js
@@ -2,25 +2,34 @@ odoo.define("my_compassion.donation_form", function (require) {
     "use strict";
 
     var publicWidget = require("web.public.widget");
+    var rpc = require("web.rpc");
 
     publicWidget.registry.DonationForm = publicWidget.Widget.extend({
         selector: ".my2_donation_form",
 
         events: {
             "change .suggested-amount": "_onAmountChange",
+            "change .SelectComponent": "_onRecipientChange",
             "click .btn-submit": "_onSubmitClick",
+            "click .limits-toggle": "_onLimitsToggleClick",
         },
 
         /**
          * @override
          */
         start: function () {
+            this.edit_mode = this.$el.data("edit-mode");
             this.customAmountInput = this.$("#custom-amount");
 
             if (this.$(".suggested-amount:checked").val() !== "custom") {
                 this.customAmountInput.hide();
             }
             this.customAmountInput.removeAttr("hidden");
+
+            this.$(".limits-info").hide();
+            this.$(".limits-info").removeAttr("hidden");
+
+            this._onRecipientChange();
 
             return this._super.apply(this, arguments);
         },
@@ -39,6 +48,55 @@ odoo.define("my_compassion.donation_form", function (require) {
         },
 
         /**
+         * Handles the change event for the recipient select.
+         * @private
+         * @param {Event} ev The jQuery event object.
+         */
+        _onRecipientChange: function (ev) {
+            const $recipient_select = this.$("[name='recipient']");
+            if ($recipient_select.length == 0) {
+                return;
+            }
+            if (this.edit_mode) {
+                this.$(".amount-selection").removeAttr("hidden");
+            } else if ($recipient_select.val()) {
+                this.$(".btn").prop("disabled", true);
+                $recipient_select.prop("disabled", true);
+
+                rpc.query({
+                    route: "/my2/gifts/get-limits",
+                    params: {
+                        product_id: this.$("[name='product_id']").val(),
+                        sponsorship_id: $recipient_select.val(),
+                    },
+                })
+                    .then(
+                        function (data) {
+                            this.$(".btn").prop("disabled", false);
+                            $recipient_select.prop("disabled", false);
+
+                            if (data.remaining_donations !== null && data.remaining_donations <= 0) {
+                                this.$(".limit-reached-message").removeAttr("hidden");
+                                this.$(".amount-selection").attr("hidden", true);
+                            } else {
+                                this.$(".amount-selection").removeAttr("hidden");
+                                this.$(".limit-reached-message").attr("hidden", true);
+                            }
+                        }.bind(this)
+                    )
+                    .guardedCatch(
+                        function () {
+                            this.$(".btn").prop("disabled", false);
+                            $recipient_select.prop("disabled", false);
+                        }.bind(this)
+                    );
+            } else {
+                this.$(".amount-selection").attr("hidden", true);
+                this.$(".limit-reached-message").attr("hidden", true);
+            }
+        },
+
+        /**
          * Handles click events on the "Add & check out" button.
          * @param {Event} ev
          */
@@ -52,16 +110,65 @@ odoo.define("my_compassion.donation_form", function (require) {
                 return; // Stop execution if validation fails
             }
 
-            // Trigger submission event
-            this.$el.trigger(this.$(".btn-submit").data("submission-event"), [
-                {
-                    product_id: this.$("[name='product_id']").val(),
-                    frequency: this.$(".donation-frequency input:checked").val(),
-                    recipient: this.$("[name='recipient']").val(),
-                    suggested_amount: this.$(".suggested-amount:checked").val(),
-                    custom_amount: this.$("[name='custom_amount']").val(),
+            const sponsorship_id = this.$("[name='recipient']").val();
+            const product_id = this.$("[name='product_id']").val();
+
+            rpc.query({
+                route: "/my2/gifts/get-limits",
+                params: {
+                    product_id: product_id,
+                    sponsorship_id: sponsorship_id,
                 },
-            ]);
+            })
+                .then(
+                    function (data) {
+                        this.$(".btn").prop("disabled", false);
+
+                        // Compute amount
+                        const suggested_amount = this.$(".suggested-amount:checked").val();
+                        const custom_amount = this.$("[name='custom_amount']").val();
+                        var amount = suggested_amount;
+                        if (amount === "custom") {
+                            amount = custom_amount;
+                        }
+
+                        console.log(data.remaining_donations);
+                        if (
+                            (data.min_amount !== null && amount < data.min_amount) ||
+                            (data.max_amount !== null && amount > data.max_amount) ||
+                            (data.remaining_donations !== null && data.remaining_donations <= 0 && !this.edit_mode)
+                        ) {
+                            this.$(".limit-error-message").removeAttr("hidden");
+                            return;
+                        } else {
+                            this.$(".limit-error-message").attr("hidden", true);
+                        }
+
+                        // Trigger submission event
+                        this.$el.trigger(this.$(".btn-submit").data("submission-event"), [
+                            {
+                                product_id: product_id,
+                                frequency: this.$(".donation-frequency input:checked").val(),
+                                recipient: sponsorship_id,
+                                suggested_amount: suggested_amount,
+                                custom_amount: custom_amount,
+                            },
+                        ]);
+                    }.bind(this)
+                )
+                .guardedCatch(
+                    function () {
+                        this.$(".btn").prop("disabled", false);
+                    }.bind(this)
+                );
+        },
+
+        /**
+         * Handles click events on the donation limits toggle.
+         * @param {Event} ev
+         */
+        _onLimitsToggleClick: function (ev) {
+            this.$(".limits-info").slideToggle("fast");
         },
 
         /**

--- a/my_compassion/templates/components/my2_donation_form.xml
+++ b/my_compassion/templates/components/my2_donation_form.xml
@@ -7,6 +7,8 @@
 
     Props:                                                                                           Default:
     - product (product.template): The associated product.                                            -required-
+    - limits (list[gift.threshold.settings]): The price limits for different donations types.        -required-
+    - date (date): The date to use for price conversions.                                            [today]
     - submit_label (string): The label of the submit button.                                         ['Add & check out']
     - submission_event (string): The custom submission event name.                                   ['donation-form:submit']
     - sponsorships (list[recurring.contract]) [only if product is a gift]: The user's sponsorships.  [none]
@@ -18,9 +20,33 @@
     - top_class (string): Classes to add to the top element of the item.                             [none]
 -->
 <odoo>
+    <template id="DonationFormLimitsInfo">
+        <div class="limits-info my-3" hidden="">
+            <t t-call="my_compassion.GivingLimitsTableComponent" />
+            <div class="mt-3 p-3 rounded-lg bg-light-blue">
+                <div class="tiny-text">
+                    If you'd like to make a large donation to support the work of  Compassion, please get in
+                    touch with us directly and we can suggest how  your donation can make the greatest
+                    impact.
+                </div>
+                <div class="mt-3 tiny-text">
+                    <i class="mr-1 icon-phone body-small" />
+                    <a href="tel:+41244342124" class="text-low-black">+41 (0)24 434 21 24</a>
+                    (Lu-Ven: 9.00-14.00)
+                </div>
+                <div class="mt-2 tiny-text">
+                    <i class="mr-1 icon-mail01 body-small" />
+                    <a t-attf-href="mailto:#{request.env.company.email}" class="text-low-black">
+                        <t t-esc="request.env.company.email" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </template>
     <!-- DONATION FORM COMPONENT -->
     <template id="DonationFormComponent" name="Donation Form Component">
         <!-- Default property values -->
+        <t t-set="edit_mode" t-value="edit_mode or False" />
         <t t-set="submit_label" t-value="submit_label or 'Add &amp; check out'" />
         <t t-set="submission_event" t-value="submission_event or 'donation-form:submit'" />
         <t t-set="default_frequency" t-value="default_frequency or 'one_time'" />
@@ -42,9 +68,9 @@
                 <t
                     t-set="options"
                     t-value="[
-                    ('one_time', 'One Time'),
-                    ('monthly', 'Monthly'),
-                ]"
+                        ('one_time', 'One Time'),
+                        ('monthly', 'Monthly'),
+                    ]"
                 />
                 <t t-set="default" t-value="default_frequency" />
                 <t t-set="top_class" t-value="'mt-3 align-self-center donation-frequency'" />
@@ -67,106 +93,126 @@
                     </t>
                 </t>
             </t>
-            <t t-call="theme_compassion_2025.FormFieldComponent">
-                <t t-set="top_class" t-value="'mt-4 w-100'" />
-                <t t-set="label" t-value="'Suggested amounts'" />
-                <div class="mt-1 d-flex justify-content-between">
-                    <div class="donation-suggested-amount flex-grow-1">
-                        <input
-                            t-attf-id="#{base_name}-suggested-low"
-                            type="radio"
-                            t-attf-name="#{base_name}_suggested_amount"
-                            value="low"
-                            t-att-checked="default_suggested_amount == 'low'"
-                            class="suggested-amount"
-                        />
-                        <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-low">
-                            <t
-                                t-set="price"
-                                t-value="product.my_compassion_donation_quantity_low * product.list_price"
-                            />
-                            CHF
-                            <t t-if="price % 1 == 0" t-esc="int(price)" />
-                            <t t-else="" t-esc="'{0:.2f}'.format(price)" />
-                        </label>
-                    </div>
-                    <div class="donation-suggested-amount mx-3 flex-grow-1">
-                        <input
-                            t-attf-id="#{base_name}-suggested-medium"
-                            type="radio"
-                            t-attf-name="#{base_name}_suggested_amount"
-                            value="medium"
-                            t-att-checked="default_suggested_amount == 'medium'"
-                            class="suggested-amount"
-                        />
-                        <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-medium">
-                            <t
-                                t-set="price"
-                                t-value="product.my_compassion_donation_quantity_medium * product.list_price"
-                            />
-                            CHF
-                            <t t-if="price % 1 == 0" t-esc="int(price)" />
-                            <t t-else="" t-esc="'{0:.2f}'.format(price)" />
-                        </label>
-                    </div>
-                    <div class="donation-suggested-amount flex-grow-1">
-                        <input
-                            t-attf-id="#{base_name}-suggested-high"
-                            type="radio"
-                            t-attf-name="#{base_name}_suggested_amount"
-                            value="high"
-                            t-att-checked="default_suggested_amount == 'high'"
-                            class="suggested-amount"
-                        />
-                        <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-high">
-                            <t
-                                t-set="price"
-                                t-value="product.my_compassion_donation_quantity_high * product.list_price"
-                            />
-                            CHF
-                            <t t-if="price % 1 == 0" t-esc="int(price)" />
-                            <t t-else="" t-esc="'{0:.2f}'.format(price)" />
-                        </label>
-                    </div>
+            <div class="limit-reached-message" hidden="">
+                <div class="mt-3 text-mid-grey text-center body-large bold">
+                    Donation limit reached for this donation type.
                 </div>
-            </t>
-            <t t-call="theme_compassion_2025.FormFieldComponent">
-                <t t-set="top_class" t-value="'mt-3 w-100'" />
-                <t t-set="label" t-value="'Or enter your own amount'" />
-                <t t-set="invalid_hint" t-value="'Please enter a valid amount.'" />
-                <div class="donation-suggested-amount">
-                    <input
-                        t-attf-id="#{base_name}-suggested-custom"
-                        type="radio"
-                        t-attf-name="#{base_name}_suggested_amount"
-                        value="custom"
-                        t-att-checked="default_suggested_amount == 'custom'"
-                        class="suggested-amount"
-                    />
-                    <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-custom">Custom amount</label>
+                <div class="mb-3 tiny-text bold text-center">
+                    <span class="limits-toggle text-core-blue">Learn more</span>
                 </div>
-                <input
-                    id="custom-amount"
-                    type="text"
-                    name="custom_amount"
-                    placeholder="CHF"
-                    class="form-control mt-2"
-                    hidden=""
-                    t-att-value="'{:g}'.format(default_custom_amount) if default_custom_amount else ''"
-                />
-            </t>
-            <div
-                class="btn-submit align-self-stretch my-4 d-flex flex-column align-items-stretch"
-                t-att-data-submission-event="submission_event"
-            >
-                <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                    <t t-set="variant" t-value="'default'" />
-                    <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label" t-value="submit_label" />
-                    <t t-set="color" t-value="'mid-green'" />
-                    <t t-set="text_color" t-value="'pure-white'" />
-                </t>
+                <t t-call="my_compassion.DonationFormLimitsInfo" />
+                <div class="mb-3" />
             </div>
+            <div class="amount-selection" t-att-hidden="product.my_compassion_donation_type == 'gift'">
+                <t t-call="theme_compassion_2025.FormFieldComponent">
+                    <t t-set="top_class" t-value="'mt-4 w-100'" />
+                    <t t-set="label" t-value="'Suggested amounts'" />
+                    <div class="mt-1 d-flex justify-content-between">
+                        <div class="donation-suggested-amount flex-grow-1">
+                            <input
+                                t-attf-id="#{base_name}-suggested-low"
+                                type="radio"
+                                t-attf-name="#{base_name}_suggested_amount"
+                                value="low"
+                                t-att-checked="default_suggested_amount == 'low'"
+                                class="suggested-amount"
+                            />
+                            <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-low">
+                                <t
+                                    t-set="price"
+                                    t-value="product.my_compassion_donation_quantity_low * product.list_price"
+                                />
+                                CHF
+                                <t t-if="price % 1 == 0" t-esc="int(price)" />
+                                <t t-else="" t-esc="'{0:.2f}'.format(price)" />
+                            </label>
+                        </div>
+                        <div class="donation-suggested-amount mx-3 flex-grow-1">
+                            <input
+                                t-attf-id="#{base_name}-suggested-medium"
+                                type="radio"
+                                t-attf-name="#{base_name}_suggested_amount"
+                                value="medium"
+                                t-att-checked="default_suggested_amount == 'medium'"
+                                class="suggested-amount"
+                            />
+                            <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-medium">
+                                <t
+                                    t-set="price"
+                                    t-value="product.my_compassion_donation_quantity_medium * product.list_price"
+                                />
+                                CHF
+                                <t t-if="price % 1 == 0" t-esc="int(price)" />
+                                <t t-else="" t-esc="'{0:.2f}'.format(price)" />
+                            </label>
+                        </div>
+                        <div class="donation-suggested-amount flex-grow-1">
+                            <input
+                                t-attf-id="#{base_name}-suggested-high"
+                                type="radio"
+                                t-attf-name="#{base_name}_suggested_amount"
+                                value="high"
+                                t-att-checked="default_suggested_amount == 'high'"
+                                class="suggested-amount"
+                            />
+                            <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-high">
+                                <t
+                                    t-set="price"
+                                    t-value="product.my_compassion_donation_quantity_high * product.list_price"
+                                />
+                                CHF
+                                <t t-if="price % 1 == 0" t-esc="int(price)" />
+                                <t t-else="" t-esc="'{0:.2f}'.format(price)" />
+                            </label>
+                        </div>
+                    </div>
+                </t>
+                <t t-call="theme_compassion_2025.FormFieldComponent">
+                    <t t-set="top_class" t-value="'my-3 w-100'" />
+                    <t t-set="label" t-value="'Or enter your own amount'" />
+                    <t t-set="invalid_hint" t-value="'Please enter a valid amount.'" />
+                    <div class="donation-suggested-amount">
+                        <input
+                            t-attf-id="#{base_name}-suggested-custom"
+                            type="radio"
+                            t-attf-name="#{base_name}_suggested_amount"
+                            value="custom"
+                            t-att-checked="default_suggested_amount == 'custom'"
+                            class="suggested-amount"
+                        />
+                        <label class="mb-0 w-100" t-attf-for="#{base_name}-suggested-custom">Custom amount</label>
+                    </div>
+                    <input
+                        id="custom-amount"
+                        type="text"
+                        name="custom_amount"
+                        placeholder="CHF"
+                        class="form-control mt-2"
+                        hidden=""
+                        t-att-value="'{:g}'.format(default_custom_amount) if default_custom_amount else ''"
+                    />
+                </t>
+                <div class="limit-error-message" hidden="">
+                    <div class="mt-3 tiny-text text-center text-mid-orange">
+                        The amount must comply with our
+                        <span class="limits-toggle text-core-blue">donation limits</span>
+                    </div>
+                    <t t-call="my_compassion.DonationFormLimitsInfo" />
+                </div>
+                <div
+                    class="btn-submit align-self-stretch my-2 d-flex flex-column align-items-stretch"
+                    t-att-data-submission-event="submission_event"
+                >
+                    <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                        <t t-set="variant" t-value="'default'" />
+                        <t t-set="variation" t-value="'filled'" />
+                        <t t-set="label" t-value="submit_label" />
+                        <t t-set="color" t-value="'mid-green'" />
+                        <t t-set="text_color" t-value="'pure-white'" />
+                    </t>
+                </div>
+            </div>
+            <div class="mb-4" />
         </div>
     </template>
 </odoo>

--- a/my_compassion/templates/components/my2_donation_product.xml
+++ b/my_compassion/templates/components/my2_donation_product.xml
@@ -5,14 +5,15 @@
     Description:
     A product representing a donation the user can add to their gift package.
 
-    Props:                                                                                   Default:
-    - product (product.template record): The associated product                              -required-
-    - submission_event (string): The custom submission event name.                           ['donation-form:submit']
-    - title_color (string): Color of the title.                                              [dark-blue]
-    - accent_color (string): Color of the left border accent.                                [dark-blue]
-    - price_color (string): Color of the price.                                              [dark-blue]
-    - bg_color (string): Background color.                                                   [high-eggshell]
-    - top_class (string): Classes to add to the top element of the product.                  [none]
+    Props:                                                                                      Default:
+    - product (product.template record): The associated product                                 -required-
+    - limits (list[gift.threshold.settings]): The price limits for different donations types.   -required-
+    - submission_event (string): The custom submission event name.                              ['donation-form:submit']
+    - title_color (string): Color of the title.                                                 [dark-blue]
+    - accent_color (string): Color of the left border accent.                                   [dark-blue]
+    - price_color (string): Color of the price.                                                 [dark-blue]
+    - bg_color (string): Background color.                                                      [high-eggshell]
+    - top_class (string): Classes to add to the top element of the product.                     [none]
 -->
 <odoo>
     <!-- DONATION PRODUCT COMPONENT -->

--- a/my_compassion/templates/components/my2_giving_limits_modal.xml
+++ b/my_compassion/templates/components/my2_giving_limits_modal.xml
@@ -10,21 +10,6 @@
     - modal_id (string): The id of the modal element.                                            ['giving-limits-modal']
 -->
 <odoo>
-    <!-- GIVING LIMITS MODAL TABLE COLUMN -->
-    <template id="my2_giving_limits_modal_table_column" name="Gift Package Help Table Column">
-        <div t-attf-class="table-column d-flex flex-column #{top_class}">
-            <div class="table-cell tiny-text bold bg-light-green border-0 d-flex flex-column justify-content-center">
-                <t t-esc="title" />
-            </div>
-            <t t-foreach="cells" t-as="cell">
-                <div class="table-cell super-tiny-text d-flex flex-column justify-content-center">
-                    <div>
-                        <t t-raw="cell.replace('*', '&lt;span class=\'body-small text-low-pink\'&gt;*&lt;/span&gt;')" />
-                    </div>
-                </div>
-            </t>
-        </div>
-    </template>
     <!-- GIVING LIMITS MODAL COMPONENT -->
     <template id="GivingLimitsModalComponent" name="Giving Limits Modal Component">
         <!-- Default property values -->
@@ -62,56 +47,8 @@
                             is to encourage a culture of dependency on gifts. Also, we don't want to overwhelm
                             families or single them out for special treatment, which is why we have limits in place.
                         </div>
-                        <div class="d-flex flex-column my-4">
-                            <!-- TABLE TITLE -->
-                            <div class="p-3 table-title col-12 bg-low-green tiny-text text-center text-pure-white">
-                                Annual gift limits in Switzerland
-                            </div>
-                            <!-- COLUMNS -->
-                            <div class="d-flex">
-                                <!-- TYPE -->
-                                <t t-call="my_compassion.my2_giving_limits_modal_table_column">
-                                    <t t-set="top_class" t-value="'flex-grow-1'" />
-                                    <t t-set="title" t-value="'Type'" />
-                                    <t
-                                        t-set="cells"
-                                        t-value="[
-                                        (limit.sponsorship_gift_type + ' Gift' if limit.sponsorship_gift_type else limit.gift_type) +
-                                        ('*' if limit.yearly_threshold and limit.gift_frequency == 2 else
-                                         '**' if not limit.yearly_threshold and limit.gift_frequency == 1 else '')
-                                        for limit in limits
-                                    ]"
-                                    />
-                                </t>
-                                <!-- MIN -->
-                                <t t-call="my_compassion.my2_giving_limits_modal_table_column">
-                                    <t t-set="title" t-value="'Min'" />
-                                    <t
-                                        t-set="cells"
-                                        t-value="[
-                                        'CHF {:g}'.format(limit.min_amount)
-                                        for limit in limits
-                                    ]"
-                                    />
-                                </t>
-                                <!-- MAX -->
-                                <t t-call="my_compassion.my2_giving_limits_modal_table_column">
-                                    <t t-set="title" t-value="'Max'" />
-                                    <t
-                                        t-set="cells"
-                                        t-value="[
-                                        'CHF {:,g}'.format(limit.max_amount)
-                                        for limit in limits
-                                    ]"
-                                    />
-                                </t>
-                            </div>
-                            <!-- NOTES -->
-                            <div class="px-3 pt-1 super-tiny-text text-low-pink">
-                                *A child gift can be given twice a year.
-                                <br />
-                                **Available in the child's final year of the program.
-                            </div>
+                        <div class="my-4">
+                            <t t-call="my_compassion.GivingLimitsTableComponent" />
                         </div>
                         <div class="tiny-text">
                             If you'd like to make a large donation to support the work of  Compassion, please get in

--- a/my_compassion/templates/components/my2_giving_limits_table.xml
+++ b/my_compassion/templates/components/my2_giving_limits_table.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Component: Giving Limits Table
+
+    Description:
+    A table displaying the giving limits.
+
+    Props:                                                                                       Default:
+    - limits (list[gift.threshold.settings]): The price limits for different donations types.    -required-
+    - date (date): The date to use for price conversions.                                        [today]
+-->
+<odoo>
+    <!-- GIVING LIMITS TABLE COLUMN -->
+    <template id="my2_giving_limits_modal_table_column" name="Gift Package Help Table Column">
+        <div t-attf-class="table-column d-flex flex-column #{top_class}">
+            <div class="table-cell tiny-text bold bg-light-green border-0 d-flex flex-column justify-content-center">
+                <t t-esc="title" />
+            </div>
+            <t t-foreach="cells" t-as="cell">
+                <div class="table-cell super-tiny-text d-flex flex-column justify-content-center">
+                    <div>
+                        <t t-raw="cell.replace('*', '&lt;span class=\'body-small text-low-pink\'&gt;*&lt;/span&gt;')" />
+                    </div>
+                </div>
+            </t>
+        </div>
+    </template>
+    <!-- GIVING LIMITS TABLE COMPONENT -->
+    <template id="GivingLimitsTableComponent" name="Giving Limits Table Component">
+        <!-- Include stylesheet -->
+        <link rel="stylesheet" href="/my_compassion/static/src/css/my2_giving_limits_table.css" />
+        <t t-set="company" t-value="request.website.company_id" />
+        <t t-set="date" t-value="date or datetime.date.today()" />
+        <div class="giving-limits-table d-flex flex-column">
+            <!-- TABLE TITLE -->
+            <div class="p-3 table-title col-12 bg-low-green tiny-text text-center text-pure-white">
+                Annual gift limits in Switzerland
+            </div>
+            <!-- COLUMNS -->
+            <div class="d-flex">
+                <!-- TYPE -->
+                <t t-call="my_compassion.my2_giving_limits_modal_table_column">
+                    <t t-set="top_class" t-value="'flex-grow-1'" />
+                    <t t-set="title" t-value="'Type'" />
+                    <t
+                        t-set="cells"
+                        t-value="[
+                        (limit.sponsorship_gift_type + ' Gift' if limit.sponsorship_gift_type else limit.gift_type) +
+                        ('*' if limit.yearly_threshold and limit.gift_frequency == 2 else
+                         '**' if not limit.yearly_threshold and limit.gift_frequency == 1 else '')
+                        for limit in limits
+                    ]"
+                    />
+                </t>
+                <!-- MIN -->
+                <t t-call="my_compassion.my2_giving_limits_modal_table_column">
+                    <t t-set="title" t-value="'Min'" />
+                    <t
+                        t-set="cells"
+                        t-value="[
+                        'CHF {:g}'.format(limit.currency_id._convert(limit.min_amount, company.currency_id, company, date))
+                        for limit in limits
+                    ]"
+                    />
+                </t>
+                <!-- MAX -->
+                <t t-call="my_compassion.my2_giving_limits_modal_table_column">
+                    <t t-set="title" t-value="'Max'" />
+                    <t
+                        t-set="cells"
+                        t-value="[
+                        'CHF {:g}'.format(limit.currency_id._convert(limit.max_amount, company.currency_id, company, date))
+                        for limit in limits
+                    ]"
+                    />
+                </t>
+            </div>
+            <!-- NOTES -->
+            <div class="px-3 pt-1 super-tiny-text text-low-pink">
+                *A child gift can be given twice a year.
+                <br />
+                **Available in the child's final year of the program.
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/my_compassion/templates/pages/my2_donation_details.xml
+++ b/my_compassion/templates/pages/my2_donation_details.xml
@@ -11,6 +11,7 @@
     Injected data:
     - product ('product.template' record): The donation product.
     - sponsorships ('recurring.contract' records): The list of the user's sponsorships.
+    - donation_limits ('gift.threshold.settings' records): The price limits for different donations types.
 -->
 <odoo>
     <!-- DONATION DETAILS PAGE -->
@@ -94,6 +95,7 @@
                         <!-- DONATE -->
                         <t t-call="my_compassion.DonationFormComponent">
                             <t t-set="top_class" t-value="'mt-3 mb-4'" />
+                            <t t-set="limits" t-value="donation_limits" />
                         </t>
                     </div>
                 </div>

--- a/my_compassion/templates/pages/my2_gift_package.xml
+++ b/my_compassion/templates/pages/my2_gift_package.xml
@@ -202,7 +202,11 @@
                                         data-dismiss="modal"
                                         aria-label="Close"
                                     />
-                                    <div id="edit-donation-form" class="d-flex justify-content-center" />
+                                    <div
+                                        id="edit-donation-form"
+                                        class="d-flex justify-content-center"
+                                        data-edit-mode="true"
+                                    />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Enforce donation amount thresholds according to the Compassion guidelines.

Note that this PR only adds frontend checks. Checks should also be added on the backend before proceeding to payment (after #129 has been merged). For that, take inspiration from as in `my2_donation_form.js` and `MyCompassionDonationsController.donation_get_limits()`.

### Images

<img width="745" height="876" alt="image" src="https://github.com/user-attachments/assets/f3760708-4536-45ec-a543-f9f977e36d53" />

<img width="578" height="892" alt="image" src="https://github.com/user-attachments/assets/a688f142-d639-4c25-a583-fdec855d25e4" />

<img width="745" height="628" alt="image" src="https://github.com/user-attachments/assets/5c318c27-07af-498e-b87f-7a536fcbad7f" />