### PR TITLE
mail sends when partner modifies his info

### DIFF
--- a/my_compassion/controllers/my2_user_settings.py
+++ b/my_compassion/controllers/my2_user_settings.py
@@ -11,6 +11,7 @@ from datetime import date
 from odoo import api, http
 from odoo.exceptions import ValidationError
 from odoo.http import request
+from odoo.tools import html_escape
 
 
 class MyCompassionUserController(http.Controller):
@@ -86,11 +87,62 @@ class MyCompassionUserController(http.Controller):
             # When an address component is changed, reset the linked zip_id
             if any(k in vals_to_update for k in ["city", "zip", "country_id"]):
                 vals_to_update["zip_id"] = False
+
+            # getting old values for email notification of the changes
+            old_values = {f: getattr(partner, f) for f in vals_to_update.keys()}
+
             try:
                 partner.sudo().write(vals_to_update)
             except ValidationError as e:
                 if "email" in vals_to_update:
                     return {"success": False, "errors": {"email": e.args[0]}}
+
+            new_values = {f: getattr(partner, f) for f in vals_to_update.keys()}
+
+            # Prepare change summary for notification
+            changes = []
+            for field, _ in vals_to_update.items():
+                # those are compute
+                if field in ("zip_id", "email_bounced", "preferred_name"):
+                    continue
+
+                old_val = old_values.get(field)
+                new_val = new_values.get(field)
+
+                # transforming the database values to a user-friendly
+                # format for the staff
+                match field:
+                    case "title" | "country_id":
+                        old_val_userfriendly = old_val.name if old_val else ""
+                        new_val_userfriendly = new_val.name if new_val else ""
+                    case _:
+                        old_val_userfriendly = str(old_val or "")
+                        new_val_userfriendly = str(new_val or "")
+
+                if old_val_userfriendly != new_val_userfriendly:
+                    changes.append(
+                        f"<li><b>{field}</b>: {html_escape(old_val_userfriendly)} → "
+                        f"{html_escape(new_val_userfriendly)}</li>"
+                    )
+
+            if changes:
+                body_html = (
+                    f"<p>Sponsor <b>{html_escape(partner.name)}</b>, "
+                    f"with user_id <b>{partner.id}</b> "
+                    f"has updated their personal information via MyCompassion. "
+                    f"Please review the changes:</p>"
+                    f"<ul>{''.join(changes)}</ul>"
+                )
+
+                # Send the notification email
+                mail_values = {
+                    "subject": f"Partner data change - {partner.name} "
+                    f"(Ref {partner.ref})",
+                    "body_html": body_html,
+                    # TODO : replace with a setting in v17
+                    "email_to": "sds_requests@compassion.ch",
+                }
+                request.env["mail.mail"].sudo().create(mail_values)
 
         return {"success": True}
 


### PR DESCRIPTION
When a partner changes his info in the page user_settings, a mail is sent to sds_requests@compassion.ch with the applied changes so that those can be reviewed.

The mail looks like this:
<img width="929" height="783" alt="Screenshot from 2025-09-18 12-47-04" src="https://github.com/user-attachments/assets/d19da802-57b8-445d-9b5f-af8e9e188324" />
