### PR TITLE
T2677 add under vignette button see terminated sponsorships in dashboard

### DIFF
--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -76,10 +76,9 @@ class Partner(models.Model):
                     ("child_id", "!=", False),
                 ],
             )
-            partner.is_ex_sponsor = (
-                any(s.state == "terminated" for s in sponsorships)
-                and all(s.state in ["terminated", "cancelled"] for s in sponsorships)
-            )
+            partner.is_ex_sponsor = any(
+                s.state == "terminated" for s in sponsorships
+            ) and all(s.state in ["terminated", "cancelled"] for s in sponsorships)
 
     def _compute_is_donor(self):
         donors_data = self.env["account.move.line"].read_group(

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -77,8 +77,7 @@ class Partner(models.Model):
                 ],
             )
             partner.is_ex_sponsor = (
-                bool(sponsorships)
-                and any(s.state == "terminated" for s in sponsorships)
+                any(s.state == "terminated" for s in sponsorships)
                 and all(s.state in ["terminated", "cancelled"] for s in sponsorships)
             )
 

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -7,6 +7,9 @@ class Partner(models.Model):
     # True if partner has ever been a sponsor.
     is_sponsor = fields.Boolean(compute="_compute_is_sponsor", compute_sudo=True)
 
+    # True if partner has been a sponsor but is not currently sponsoring a child.
+    is_ex_sponsor = fields.Boolean(compute="_compute_is_ex_sponsor", compute_sudo=True)
+
     # True if the partner has ever made a donation
     is_donor = fields.Boolean(compute="_compute_is_donor", compute_sudo=True)
 
@@ -56,6 +59,25 @@ class Partner(models.Model):
             )
 
     def _compute_is_ex_sponsor(self):
+        """
+        Compute whether the partner is an ex-sponsor.
+
+        This method checks if the partner has been a sponsor in the past but is not
+        currently sponsoring a child. It searches for all sponsorship contracts
+        associated with the partner and determines if all of them are in a
+        'terminated' state.
+        """
+        for partner in self:
+            sponsorships = self.env["recurring.contract"].search(
+                [
+                    "|",
+                    ("partner_id", "=", partner.id),
+                    ("correspondent_id", "=", partner.id),
+                    ("child_id", "!=", False),
+                ],
+            )
+            partner.is_ex_sponsor = all(s.state in ["terminated"] for s in sponsorships)
+
     def _compute_is_donor(self):
         donors_data = self.env["account.move.line"].read_group(
             domain=[

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -55,6 +55,7 @@ class Partner(models.Model):
                 ],
             )
 
+    def _compute_is_ex_sponsor(self):
     def _compute_is_donor(self):
         donors_data = self.env["account.move.line"].read_group(
             domain=[

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -65,7 +65,7 @@ class Partner(models.Model):
         This method checks if the partner has been a sponsor in the past but is not
         currently sponsoring a child. It searches for all sponsorship contracts
         associated with the partner and determines if all of them are in a
-        'terminated' state.
+        'terminated' or 'cancelled' state.
         """
         for partner in self:
             sponsorships = self.env["recurring.contract"].search(
@@ -76,7 +76,11 @@ class Partner(models.Model):
                     ("child_id", "!=", False),
                 ],
             )
-            partner.is_ex_sponsor = all(s.state in ["terminated"] for s in sponsorships)
+            partner.is_ex_sponsor = (
+                bool(sponsorships)
+                and any(s.state == "terminated" for s in sponsorships)
+                and all(s.state in ["terminated", "cancelled"] for s in sponsorships)
+            )
 
     def _compute_is_donor(self):
         donors_data = self.env["account.move.line"].read_group(

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -65,7 +65,7 @@ class Partner(models.Model):
         This method checks if the partner has been a sponsor in the past but is not
         currently sponsoring a child. It searches for all sponsorship contracts
         associated with the partner and determines if all of them are in a
-        'terminated' or 'cancelled' state.
+        'terminated' state (excluding those cancelled).
         """
         for partner in self:
             sponsorships = self.env["recurring.contract"].search(

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -111,7 +111,7 @@ Page: My Compassion 2 Dashboard Page
                 <t t-call="theme_compassion_2025.ThemedButtonComponent">
                     <t t-set="variant" t-value="'default'" />
                     <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label" t-value="'See my terminated sponsorships'" />
+                    <t t-set="label">See my terminated sponsorships</t>
                     <t t-set="icon" t-value="'pictogram-child-focused'" />
                     <t t-set="color" t-value="'core-blue'" />
                     <t t-set="icon_color" t-value="'low-yellow'" />

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -106,7 +106,7 @@ Page: My Compassion 2 Dashboard Page
                     <t t-set="href" t-value="'/my2/children/letters/new'" />
                 </t>
             </t>
-            <!-- If an ex-sponsor button to see old sponsorships  -->
+            <!-- If an ex-sponsor, creates a button to see old sponsorships  -->
             <t t-if="partner.is_ex_sponsor">
                 <t t-call="theme_compassion_2025.ThemedButtonComponent">
                     <t t-set="variant" t-value="'default'" />

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -111,7 +111,7 @@ Page: My Compassion 2 Dashboard Page
                 <t t-call="theme_compassion_2025.ThemedButtonComponent">
                     <t t-set="variant" t-value="'default'" />
                     <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label" t-value="'See my old sponsorships'" />
+                    <t t-set="label" t-value="'See my terminated sponsorships'" />
                     <t t-set="icon" t-value="'pictogram-child-focused'" />
                     <t t-set="color" t-value="'core-blue'" />
                     <t t-set="icon_color" t-value="'low-yellow'" />

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -106,6 +106,19 @@ Page: My Compassion 2 Dashboard Page
                     <t t-set="href" t-value="'/my2/children/letters/new'" />
                 </t>
             </t>
+            <!-- If an ex-sponsor button to see old sponsorships  -->
+            <t t-if="partner.is_ex_sponsor">
+                <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                    <t t-set="variant" t-value="'default'" />
+                    <t t-set="variation" t-value="'filled'" />
+                    <t t-set="label" t-value="'See my old sponsorships'" />
+                    <t t-set="icon" t-value="'pictogram-child-focused'" />
+                    <t t-set="color" t-value="'core-blue'" />
+                    <t t-set="icon_color" t-value="'low-yellow'" />
+                    <t t-set="text_color" t-value="'pure-white'" />
+                    <t t-set="href" t-value="'/my2/children'" />
+                </t>
+            </t>
         </t>
     </template>
     <!-- DONATION VIGNETTE -->


### PR DESCRIPTION
## Summary 
This PR introduces a new button to the dashboard that is shown if the user meets the following condition:
- All the sponsorships of the user are __terminated__ or __cancelled__
If the conditions are met, the user is then an __ex_sponsor__

## Key features 
- If the user is an ex_sponsor, the button is shown under the "Become a sponsor" vignette in the dashboard
- When clicking on the button, the user is redirected to the route `/my2/children` to see all their previous sponsorships. 

## Modified files 
- `/my_compassion/models/res_partner.py`: Adds the computed field __is_ex_sponsor__
- `/my_compassion/templates/pages/my2_dashboard.xml`: Adds the button 

## How to test ? 
You can use an account having only terminated sponsorships. Here are some res_users id you can use (email not shown because it's a public repo. )
- 6107
- 23718
- 8457
- 9313

Or generate one to yourself using the following query: 
` 
 SELECT
  rp.id AS partner_id,
  rp.name,
  rp.email
FROM
  res_partner AS rp
  INNER JOIN recurring_contract AS rc ON rp.id = rc.partner_id
  INNER JOIN res_users AS ru ON rp.email = ru.login
WHERE
  rp.email IS NOT NULL
GROUP BY
  rp.id,
  rp.name,
  rp.email 
HAVING
  COUNT(CASE WHEN rc.state <> 'terminated' THEN 1 END) = 0;
 `

## Screenshot
<img width="382" height="420" alt="image" src="https://github.com/user-attachments/assets/32783776-38f6-4520-8d0a-ec00a9438876" />

<img width="963" height="465" alt="image" src="https://github.com/user-attachments/assets/a01566ae-51bb-4f53-9723-e5323b52cc79" />

## Video demonstration
[Screencast from 07.10.2025 14:13:35.webm](https://github.com/user-attachments/assets/7aa26c32-a103-4ed5-94f7-4ba738c67c5e)





