### PR TITLE
T2725  inverse the button order in letter filters

### DIFF
--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -237,15 +237,6 @@
                                     </div>
                                     <!-- Ok and cancel filter actions -->
                                     <div class="d-flex w-100 justify-content-between">
-                                        <a id="filterOkBtn" data-dismiss="modal">
-                                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                                                <t t-set="variation" t-value="'filled'" />
-                                                <t t-set="color" t-value="'mid-green'" />
-                                                <t t-set="text_color" t-value="'pure-white'" />
-                                                <t t-set="variant" t-value="'compact'" />
-                                                <t t-set="label" t-value="'Ok'" />
-                                            </t>
-                                        </a>
                                         <a t-att-href="'/my2/children/letters'">
                                             <t t-call="theme_compassion_2025.ThemedButtonComponent">
                                                 <t t-set="variation" t-value="'filled'" />
@@ -253,6 +244,15 @@
                                                 <t t-set="text_color" t-value="'pure-white'" />
                                                 <t t-set="variant" t-value="'compact'" />
                                                 <t t-set="label" t-value="'Cancel'" />
+                                            </t>
+                                        </a>
+                                        <a id="filterOkBtn" data-dismiss="modal">
+                                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                                                <t t-set="variation" t-value="'filled'" />
+                                                <t t-set="color" t-value="'mid-green'" />
+                                                <t t-set="text_color" t-value="'pure-white'" />
+                                                <t t-set="variant" t-value="'compact'" />
+                                                <t t-set="label" t-value="'Ok'" />
                                             </t>
                                         </a>
                                     </div>


### PR DESCRIPTION
I corrected the position of the buttons as asked in T2725.

Now we have :
<img width="733" height="1317" alt="image" src="https://github.com/user-attachments/assets/0f4cbfc7-1382-4842-962e-f916c4389e8a" />
