### PR TITLE
T2737 - Giving limits are showing 'None' and inconsistent decimal

### DIFF
--- a/my_compassion/templates/components/my2_giving_limits_table.xml
+++ b/my_compassion/templates/components/my2_giving_limits_table.xml
@@ -58,7 +58,7 @@
                     <t
                         t-set="cells"
                         t-value="[
-                        '{} {:g}'.format(currency_name, limit.currency_id._convert(limit.min_amount, company.currency_id, company, date))
+                        '{} {:.2f}'.format(company.currency_id.name , int(limit.currency_id._convert(limit.min_amount, company.currency_id, company, date) * 10) / 10.0)
                         for limit in limits
                     ]"
                     />
@@ -69,7 +69,7 @@
                     <t
                         t-set="cells"
                         t-value="[
-                        '{} {:g}'.format(currency_name, limit.currency_id._convert(limit.max_amount, company.currency_id, company, date))
+                        '{} {:,.2f}'.format(company.currency_id.name , int(limit.currency_id._convert(limit.max_amount, company.currency_id, company, date) * 10) / 10.0)
                         for limit in limits
                     ]"
                     />

--- a/my_compassion/templates/components/my2_giving_limits_table.xml
+++ b/my_compassion/templates/components/my2_giving_limits_table.xml
@@ -69,7 +69,7 @@
                     <t
                         t-set="cells"
                         t-value="[
-                        '{} {:,.2f}'.format(company.currency_id.name , int(limit.currency_id._convert(limit.max_amount, company.currency_id, company, date) * 10) / 10.0)
+                        '{} {:.2f}'.format(company.currency_id.name , int(limit.currency_id._convert(limit.max_amount, company.currency_id, company, date) * 10) / 10.0)
                         for limit in limits
                     ]"
                     />


### PR DESCRIPTION
In this PR, I fixed the bug T2737.
Now we have a clean displaying in the Gift package information modal.

Result:
<img width="1472" height="1476" alt="Screenshot from 2025-11-04 10-43-06" src="https://github.com/user-attachments/assets/34485c93-c5b1-44ad-8520-120838f16507" />

Note that I truncated the hundredths, as mentioned in the task description. We may want to round the amount.