### PR TITLE
T2733 fix resize error on modal

### DIFF
--- a/my_compassion/static/src/js/my2_bootstrap_scrollbar_compensate_override.js
+++ b/my_compassion/static/src/js/my2_bootstrap_scrollbar_compensate_override.js
@@ -1,4 +1,17 @@
-odoo.define("my_compassion.my2_prevent_modal_resize_error", function (require) {
+/*
+ * Provides a global fix to prevent a common Bootstrap modal error.
+ * This widget overrides the 'compensateScrollbar' function, which can
+ * cause the UI to crash when modals are open and the window is resized.
+ *
+ * This patch applies globally to all Bootstrap modals (.modal-dialog)
+ * on the public website as long as this asset is loaded.
+ *
+ * If this fix is needed for other components, the 'selector'
+ * in the widget can be extended to include them as well.
+ *
+ * Ticket: [T2733]
+ * ------------------------------------------------------------------------------- */
+odoo.define("my_compassion.my2_bootstrap_scrollbar_compensate_override", function (require) {
     "use strict";
 
     const publicWidget = require("web.public.widget");

--- a/my_compassion/static/src/js/my2_prevent_modal_resize_error.js
+++ b/my_compassion/static/src/js/my2_prevent_modal_resize_error.js
@@ -3,17 +3,17 @@ odoo.define("my_compassion.my2_prevent_modal_resize_error", function (require) {
 
     const publicWidget = require("web.public.widget");
 
-    publicWidget.registry.TemplateSelectionWidget = publicWidget.Widget.extend({
+    publicWidget.registry.ModalResizeFixWidget = publicWidget.Widget.extend({
         selector: ".modal-dialog",
         start: function () {
             this._super.apply(this, arguments);
 
             if (!window.jQuery) {
-                console.error("TemplateSelectionWidget: Global jQuery not found.");
+                console.error("ModalResizeFixWidget: Global jQuery not found.");
                 return;
             }
 
-            // override bootstrap scroll event method
+            // Override Bootstrap's scrollbar compensation logic
             if (window.jQuery.fn.compensateScrollbar) {
                 window.jQuery.fn.compensateScrollbar = function () {
                     return this;
@@ -22,5 +22,5 @@ odoo.define("my_compassion.my2_prevent_modal_resize_error", function (require) {
         },
     });
 
-    return publicWidget.registry.TemplateSelectionWidget;
+    return publicWidget.registry.ModalResizeFixWidget;
 });

--- a/my_compassion/static/src/js/my2_prevent_modal_resize_error.js
+++ b/my_compassion/static/src/js/my2_prevent_modal_resize_error.js
@@ -1,0 +1,28 @@
+    odoo.define('my_compassion.my2_prevent_modal_resize_error', function (require) {
+        "use strict";
+
+        const publicWidget = require("web.public.widget");
+
+        publicWidget.registry.TemplateSelectionWidget = publicWidget.Widget.extend({
+            selector: ".modal-dialog",
+            start: function () {
+
+                this._super.apply(this, arguments);
+
+                if (!window.jQuery) {
+                    console.error("TemplateSelectionWidget: Global jQuery not found.");
+                    return;
+                }
+
+                // override bootstrap scroll event method
+                if (window.jQuery.fn.compensateScrollbar) {
+                    window.jQuery.fn.compensateScrollbar = function () {
+                        return this;
+                    };
+                }
+
+            },
+        });
+
+        return publicWidget.registry.TemplateSelectionWidget;
+    });

--- a/my_compassion/static/src/js/my2_prevent_modal_resize_error.js
+++ b/my_compassion/static/src/js/my2_prevent_modal_resize_error.js
@@ -1,28 +1,26 @@
-    odoo.define('my_compassion.my2_prevent_modal_resize_error', function (require) {
-        "use strict";
+odoo.define("my_compassion.my2_prevent_modal_resize_error", function (require) {
+    "use strict";
 
-        const publicWidget = require("web.public.widget");
+    const publicWidget = require("web.public.widget");
 
-        publicWidget.registry.TemplateSelectionWidget = publicWidget.Widget.extend({
-            selector: ".modal-dialog",
-            start: function () {
+    publicWidget.registry.TemplateSelectionWidget = publicWidget.Widget.extend({
+        selector: ".modal-dialog",
+        start: function () {
+            this._super.apply(this, arguments);
 
-                this._super.apply(this, arguments);
+            if (!window.jQuery) {
+                console.error("TemplateSelectionWidget: Global jQuery not found.");
+                return;
+            }
 
-                if (!window.jQuery) {
-                    console.error("TemplateSelectionWidget: Global jQuery not found.");
-                    return;
-                }
-
-                // override bootstrap scroll event method
-                if (window.jQuery.fn.compensateScrollbar) {
-                    window.jQuery.fn.compensateScrollbar = function () {
-                        return this;
-                    };
-                }
-
-            },
-        });
-
-        return publicWidget.registry.TemplateSelectionWidget;
+            // override bootstrap scroll event method
+            if (window.jQuery.fn.compensateScrollbar) {
+                window.jQuery.fn.compensateScrollbar = function () {
+                    return this;
+                };
+            }
+        },
     });
+
+    return publicWidget.registry.TemplateSelectionWidget;
+});

--- a/my_compassion/templates/my2_assets.xml
+++ b/my_compassion/templates/my2_assets.xml
@@ -10,7 +10,10 @@
             <script type="text/javascript" src="/my_compassion/static/src/js/toast_service.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_donation_form.js" />
-            <script type="text/javascript" src="/my_compassion/static/src/js/my2_bootstrap_scrollbar_compensate_override.js" />
+            <script
+                type="text/javascript"
+                src="/my_compassion/static/src/js/my2_bootstrap_scrollbar_compensate_override.js"
+            />
             <link rel="stylesheet" href="/my_compassion/static/src/css/toast_notification.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_children_card.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_donation_item.css" />

--- a/my_compassion/templates/my2_assets.xml
+++ b/my_compassion/templates/my2_assets.xml
@@ -10,7 +10,7 @@
             <script type="text/javascript" src="/my_compassion/static/src/js/toast_service.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_donation_form.js" />
-            <!--<script type="text/javascript" src="/my_compassion/static/src/js/my2_prevent_modal_resize_error.js" />-->
+            <script type="text/javascript" src="/my_compassion/static/src/js/my2_prevent_modal_resize_error.js" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/toast_notification.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_children_card.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_donation_item.css" />

--- a/my_compassion/templates/my2_assets.xml
+++ b/my_compassion/templates/my2_assets.xml
@@ -10,6 +10,7 @@
             <script type="text/javascript" src="/my_compassion/static/src/js/toast_service.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_donation_form.js" />
+            <!--<script type="text/javascript" src="/my_compassion/static/src/js/my2_prevent_modal_resize_error.js" />-->
             <link rel="stylesheet" href="/my_compassion/static/src/css/toast_notification.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_children_card.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_donation_item.css" />

--- a/my_compassion/templates/my2_assets.xml
+++ b/my_compassion/templates/my2_assets.xml
@@ -10,7 +10,7 @@
             <script type="text/javascript" src="/my_compassion/static/src/js/toast_service.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_child_letters.js" />
             <script type="text/javascript" src="/my_compassion/static/src/js/my2_donation_form.js" />
-            <script type="text/javascript" src="/my_compassion/static/src/js/my2_prevent_modal_resize_error.js" />
+            <script type="text/javascript" src="/my_compassion/static/src/js/my2_bootstrap_scrollbar_compensate_override.js" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/toast_notification.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_children_card.css" />
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_donation_item.css" />


### PR DESCRIPTION
This PR introduces a JS widget that targets the .modal-dialog selector. It's designed to fix a specific crash: 
`Uncaught TypeError: Cannot read properties of undefined (reading 'matches')`

**Problem:**
This error comes from Bootstrap's internal compensateScrollbar function, which is triggered on window resize. When its internal scrollEl variable is null, it attempts to access .matches, causing a fatal error that freezes the UI (shutdown).

**Solution:** 
This new widget activates when a modal is in the DOM and overrides the faulty compensateScrollbar function with an empty one. This is a safe fix because Odoo's core framework manages its own page layout, making this minor Bootstrap cosmetic function redundant. Disabling it prevents the critical crash without causing any negative side effects to the UI's behavior.

This prevents the error from ever being thrown, restoring the stable behavior we're used to when resizing a window with an open modal.