### PR TITLE
T2741 timeline should add you started sponsoring

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -70,7 +70,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 (CASE WHEN EXISTS (
                     SELECT 1 FROM recurring_contract rc
                     WHERE rc.child_id = %(child_id)s
-                      AND rc.partner_id = (%(current_partner_id)s)
+                      AND rc.partner_id = ANY(%(partner_ids)s)
                       AND rc.state NOT IN ('draft')
                       AND rc.start_date IS NOT NULL
                 )
@@ -82,7 +82,6 @@ class MyCompassionChildrenController(WebsiteChild):
             {
                 "child_id": child_id,
                 "partner_ids": partner_ids,
-                "current_partner_id": partner_ids[0],
             },
         )
         return request.env.cr.fetchone()[0] or 0

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -68,7 +68,14 @@ class MyCompassionChildrenController(WebsiteChild):
                  WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s))
                 AS total
         """
-        request.env.cr.execute(sql, {"child_id": child_id, "partner_ids": partner_ids, "current_partner_id": partner_ids[0],})
+        request.env.cr.execute(
+            sql,
+            {
+                "child_id": child_id,
+                "partner_ids": partner_ids,
+                "current_partner_id": partner_ids[0],
+            },
+        )
         # The +1 is for the "start sponsorship" record
         return request.env.cr.fetchone()[0] + 1 or 0
 
@@ -114,7 +121,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 LEFT JOIN res_currency rc ON rc.id = aml.currency_id
                 WHERE s.child_id = %(child_id)s
                   AND s.partner_id = ANY(%(partner_ids)s)
-                  
+
                   UNION ALL
 
                 SELECT

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -72,7 +72,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     WHERE rc.child_id = %(child_id)s
                       AND rc.partner_id = (%(current_partner_id)s)
                       AND rc.state NOT IN ('draft')
-                      AND rc.activation_date IS NOT NULL
+                      AND rc.start_date IS NOT NULL
                 )
                 THEN 1 ELSE 0 END)
             AS total
@@ -138,7 +138,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     '' AS metadata,
-                    rc.activation_date::timestamp AS create_date,
+                    rc.start_date::timestamp AS create_date,
                     %(title_start_sponsorship)s AS title
                 FROM recurring_contract rc
                 WHERE rc.child_id = %(child_id)s

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -70,7 +70,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 (SELECT COUNT(*) FROM recurring_contract rc
                  WHERE rc.child_id = %(child_id)s
                    AND rc.partner_id = ANY(%(partner_ids)s)
-                   AND rc.state NOT IN ('draft')
+                   AND rc.state IN ('active', 'terminated')
                    AND rc.start_date IS NOT NULL)
                 AS total
         """

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -127,7 +127,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     %(title_start_sponsorship)s AS title
                 FROM recurring_contract rc
                 WHERE rc.child_id = %(child_id)s
-                  AND rc.partner_id = (%(current_partner_id)s)
+                  AND rc.partner_id = %(current_partner_id)s
                   AND rc.state NOT IN ('draft')
 
             ) AS timeline

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -66,7 +66,16 @@ class MyCompassionChildrenController(WebsiteChild):
                 +
                 (SELECT COUNT(*) FROM sponsorship_gift
                  WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s))
-                AS total
+                +
+                (CASE WHEN EXISTS (
+                    SELECT 1 FROM recurring_contract rc
+                    WHERE rc.child_id = %(child_id)s
+                      AND rc.partner_id = (%(current_partner_id)s)
+                      AND rc.state NOT IN ('draft')
+                      AND rc.activation_date IS NOT NULL
+                )
+                THEN 1 ELSE 0 END)
+            AS total
         """
         request.env.cr.execute(
             sql,
@@ -76,8 +85,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 "current_partner_id": partner_ids[0],
             },
         )
-        # The +1 is for the "start sponsorship" record
-        return request.env.cr.fetchone()[0] + 1 or 0
+        return request.env.cr.fetchone()[0] or 0
 
     def _get_timeline_data(self, child_id, partner_ids, offset, limit):
         """Fetch paginated timeline records (correspondence + gifts) ordered by date."""

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -139,7 +139,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 FROM recurring_contract rc
                 WHERE rc.child_id = %(child_id)s
                   AND rc.partner_id = ANY(%(partner_ids)s)
-                  AND rc.state NOT IN ('draft')
+                  AND rc.state IN ('active', 'terminated')
                   AND rc.start_date IS NOT NULL
 
             ) AS timeline

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -58,7 +58,7 @@ class MyCompassionChildrenController(WebsiteChild):
         return partner.ids
 
     def _get_timeline_count(self, child_id, partner_ids):
-        """Get total count of timeline records (correspondence + gifts)."""
+        """Get total count of timeline records (correspondence + gifts + start)."""
         sql = """
             SELECT
                 (SELECT COUNT(*) FROM correspondence
@@ -68,8 +68,9 @@ class MyCompassionChildrenController(WebsiteChild):
                  WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s))
                 AS total
         """
-        request.env.cr.execute(sql, {"child_id": child_id, "partner_ids": partner_ids})
-        return request.env.cr.fetchone()[0] or 0
+        request.env.cr.execute(sql, {"child_id": child_id, "partner_ids": partner_ids, "current_partner_id": partner_ids[0],})
+        # The +1 is for the "start sponsorship" record
+        return request.env.cr.fetchone()[0] + 1 or 0
 
     def _get_timeline_data(self, child_id, partner_ids, offset, limit):
         """Fetch paginated timeline records (correspondence + gifts) ordered by date."""
@@ -113,6 +114,22 @@ class MyCompassionChildrenController(WebsiteChild):
                 LEFT JOIN res_currency rc ON rc.id = aml.currency_id
                 WHERE s.child_id = %(child_id)s
                   AND s.partner_id = ANY(%(partner_ids)s)
+                  
+                  UNION ALL
+
+                SELECT
+                    'start_sponsorship' AS model,
+                    rc.id::text AS record_id,
+                    '' AS amount,
+                    '' AS currency_name,
+                    '' AS metadata,
+                    rc.activation_date::timestamp AS create_date,
+                    %(title_start_sponsorship)s AS title
+                FROM recurring_contract rc
+                WHERE rc.child_id = %(child_id)s
+                  AND rc.partner_id = (%(current_partner_id)s)
+                  AND rc.state NOT IN ('draft')
+
             ) AS timeline
             ORDER BY create_date DESC
             LIMIT %(limit)s OFFSET %(offset)s
@@ -121,6 +138,7 @@ class MyCompassionChildrenController(WebsiteChild):
         params = {
             "child_id": child_id,
             "partner_ids": partner_ids,
+            "current_partner_id": partner_ids[0],
             "default_currency": request.env.user.currency_id.name,
             "title_corr_wrote": _("Wrote you a letter"),
             "title_corr_received": _("Received your letter"),
@@ -129,6 +147,7 @@ class MyCompassionChildrenController(WebsiteChild):
             "title_gift_grad": _("Graduation/Final gift"),
             "title_gift_family": _("Family gift"),
             "title_gift_default": _("Received a gift"),
+            "title_start_sponsorship": _("Started sponsorship"),
             "limit": limit,
             "offset": offset,
         }

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -67,15 +67,12 @@ class MyCompassionChildrenController(WebsiteChild):
                 (SELECT COUNT(*) FROM sponsorship_gift
                  WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s))
                 +
-                (CASE WHEN EXISTS (
-                    SELECT 1 FROM recurring_contract rc
-                    WHERE rc.child_id = %(child_id)s
-                      AND rc.partner_id = ANY(%(partner_ids)s)
-                      AND rc.state NOT IN ('draft')
-                      AND rc.start_date IS NOT NULL
-                )
-                THEN 1 ELSE 0 END)
-            AS total
+                (SELECT COUNT(*) FROM recurring_contract rc
+                 WHERE rc.child_id = %(child_id)s
+                   AND rc.partner_id = ANY(%(partner_ids)s)
+                   AND rc.state NOT IN ('draft')
+                   AND rc.start_date IS NOT NULL)
+                AS total
         """
         request.env.cr.execute(
             sql,
@@ -141,8 +138,9 @@ class MyCompassionChildrenController(WebsiteChild):
                     %(title_start_sponsorship)s AS title
                 FROM recurring_contract rc
                 WHERE rc.child_id = %(child_id)s
-                  AND rc.partner_id = %(current_partner_id)s
+                  AND rc.partner_id = ANY(%(partner_ids)s)
                   AND rc.state NOT IN ('draft')
+                  AND rc.start_date IS NOT NULL
 
             ) AS timeline
             ORDER BY create_date DESC
@@ -152,7 +150,6 @@ class MyCompassionChildrenController(WebsiteChild):
         params = {
             "child_id": child_id,
             "partner_ids": partner_ids,
-            "current_partner_id": partner_ids[0],
             "default_currency": request.env.user.currency_id.name,
             "title_corr_wrote": _("Wrote you a letter"),
             "title_corr_received": _("Received your letter"),

--- a/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
+++ b/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
@@ -89,6 +89,23 @@
                     </a>
                 </div>
             </t>
+            <t t-elif="item['model'] == 'start_sponsorship'">
+                <div class="cd-timeline__block">
+                    <div class="cd-timeline__img bg-high-green">
+                        <i class="pictogram pictogram-child-sponsorship bg-low-black" />
+                    </div>
+                    <div class="cd-timeline__content text-component">
+                        <p class="modal-title text-core-blue">
+                            <t t-esc="item['title']" />
+                        </p>
+                        <div class="flex justify-between items-center">
+                            <span class="cd-timeline__date">
+                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </t>
         </t>
     </template>
 </odoo>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -11,7 +11,12 @@
 
     Injected data:
     - compassion_child (record): The related child object.
+    - records (list): timeline items to display.
+    - has_more_records (boolean): Indicates if there are more records to load.
     - access_scope (string): 'public' or 'sponsor'.
+    - google_api_key (string): API key for Google Maps integration.
+    - google_custom_map_id (string): Custom map ID for Google Maps integration.
+    - timezone (string): Timezone of the child's project location.
 
     TO DO: inject a list of significant sponsorship events.
 -->


### PR DESCRIPTION
Implementation of the feature requested in T2739 : I added a "Started sponsorship" event in the timeline.

Here's the result : 
<img width="1735" height="936" alt="image" src="https://github.com/user-attachments/assets/369022f0-3c3a-48f3-8830-e04bf5cd69ee" />
<img width="1735" height="1448" alt="image" src="https://github.com/user-attachments/assets/8eefae93-e9a2-41c4-838c-20c5c33ecc66" />

I have made some assumptions that can be wrong, so just to be sure:
- Started sponsorship date is reccuring.contract.activation_date
- Every reccuring contract has an activation date

Idea for further improvement : Add an event in the timeline when a sponsorship ends