### PR TITLE
T2753 Fix children card layout on `/my2/sponsorships`

### DIFF
--- a/my_compassion/templates/pages/my2_sponsorships.xml
+++ b/my_compassion/templates/pages/my2_sponsorships.xml
@@ -27,7 +27,7 @@ Page: My Compassion 2 Sponsorships Page
     <!-- RESULTS CONTENT -->
     <template id="my2_sponsorships_results_content" name="Sponsorships Results Dynamic Content">
         <t t-foreach="children" t-as="child">
-            <div class="col flex-grow-0">
+            <div class="col-12 col-md-6 col-lg-4 mb-4">
                 <t t-call="my_compassion.my2_children_card_component">
                     <t t-set="child" t-value="child" />
                     <t t-set="show_sponsor_me" t-value="True" />
@@ -119,7 +119,7 @@ Page: My Compassion 2 Sponsorships Page
                         children found
                     </div>
                     <!-- CHILDREN PROFILES -->
-                    <div class="sponsorships-results-content row justify-content-center" />
+                    <div class="sponsorships-results-content row justify-content-center g-4" />
                 </div>
                 <!-- BUTTONS -->
                 <div class="sponsorships-column d-flex mt-4 mb-5">


### PR DESCRIPTION
In this PR I corrected the display of the children cards in `my2/sponsorships` page.

Previously we had too narrow cards on this page, that was not consistent with the rest of the site.
Now we have one card per row on mobile, and max 3 on a large screen, that's the same layout pattern as the **Your Sponsorships** page `my2/children` for visual consistency.

Here's the result : 
<img width="429" height="719" alt="Screenshot from 2025-11-11 09-48-08" src="https://github.com/user-attachments/assets/a34a838a-f3e7-4145-92e9-b7ddeff90b54" />
<img width="2480" height="2101" alt="Screenshot from 2025-11-10 16-33-10" src="https://github.com/user-attachments/assets/614ca5af-f656-44ce-aee3-230490401246" />
