### PR TITLE
T2751 Clicking on the compassion logo in the menu should redirect to dashboard

### DIFF
--- a/my_compassion/controllers/__init__.py
+++ b/my_compassion/controllers/__init__.py
@@ -23,4 +23,5 @@ from . import (
     my2_auth_signup,
     my2_event_banner,
     my2_portal,
+    my2_home_redirect,
 )

--- a/my_compassion/controllers/__init__.py
+++ b/my_compassion/controllers/__init__.py
@@ -22,6 +22,6 @@ from . import (
     my2_login,
     my2_auth_signup,
     my2_event_banner,
-    my2_portal,
     my2_home_redirect,
+    my2_portal,
 )

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -23,6 +23,4 @@ class WebsiteHomeRedirect(Website):
         If the user is not logged in, they are redirected to the login page.
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
-        if request.session.uid:
-            return request.redirect("/my2/dashboard/")
-        return request.redirect("/web/login")
+        return request.redirect("/my2/dashboard/")

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -13,6 +13,7 @@ from odoo.http import request
 
 from odoo.addons.website.controllers.main import Website
 
+
 class WebsiteHomeRedirect(Website):
     @http.route("/", type="http", auth="public", website=True, sitemap=False)
     def home(self, *args, **kw):
@@ -23,5 +24,5 @@ class WebsiteHomeRedirect(Website):
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
         if request.session.uid:
-            return request.redirect('/my2/dashboard/')
-        return request.redirect('/web/login')
+            return request.redirect("/my2/dashboard/")
+        return request.redirect("/web/login")

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -26,7 +26,7 @@ class WebsiteHomeRedirect(Website):
 
         if request.website == request.env.ref("my_compassion.my2_website"):
             if request.session.uid:
-                return request.redirect("/my2/dashboard/")
+                return request.redirect("/my2/dashboard")
             else:
                 return request.redirect("/web/login")
         return super().home(*args, **kw)

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -23,4 +23,6 @@ class WebsiteHomeRedirect(Website):
         If the user is not logged in, they are redirected to the login page.
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
-        return request.redirect("/my2/dashboard/")
+        if request.website == request.env.ref("my_compassion.my2_website"):
+            return request.redirect("/my2/dashboard/")
+        return super().home(*args, **kwargs)

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -1,0 +1,25 @@
+##############################################################################
+#
+#    Copyright (C) 2025 Compassion CH (http://www.compassion.ch)
+#    @author: Samuel Bachmann <samuel.bachmann02@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+from odoo.addons.website.controllers.main import Website
+
+class WebsiteHomeRedirect(Website):
+    @http.route("/", type="http", auth="public", website=True, sitemap=False)
+    def home(self, *args, **kw):
+        """
+        Redirects the home page.
+        If the user is already logged in, they are redirected to the dashboard.
+        If the user is not logged in, they are redirected to the login page.
+        `my2_login.py` handles the redirection from the login page to the dashboard.
+        """
+        return request.redirect("/web/login")

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -23,6 +23,10 @@ class WebsiteHomeRedirect(Website):
         If the user is not logged in, they are redirected to the login page.
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
+
         if request.website == request.env.ref("my_compassion.my2_website"):
-            return request.redirect("/my2/dashboard/")
-        return super().home(*args, **kwargs)
+            if request.session.uid:
+                return request.redirect("/my2/dashboard/")
+            else:
+                return request.redirect("/web/login")
+        return super().home(*args, **kw)

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -22,4 +22,6 @@ class WebsiteHomeRedirect(Website):
         If the user is not logged in, they are redirected to the login page.
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
-        return request.redirect("/web/login")
+        if request.session.uid:
+            return request.redirect('/my2/dashboard/')
+        return request.redirect('/web/login')

--- a/my_compassion/controllers/my2_login.py
+++ b/my_compassion/controllers/my2_login.py
@@ -24,7 +24,7 @@ class WebsiteLoginRedirect(Website):
         # Check if a user ID exists in the current session
         if request.session.uid:
             # If so, redirect the user to their account page or dashboard
-            return request.redirect("/my2/dashboard/")
+            return request.redirect("/my2/dashboard")
 
         # If the user is not logged in, execute the original Odoo logic for login
         return super().web_login(*args, **kw)

--- a/my_compassion/controllers/my2_login.py
+++ b/my_compassion/controllers/my2_login.py
@@ -24,7 +24,7 @@ class WebsiteLoginRedirect(Website):
         # Check if a user ID exists in the current session
         if request.session.uid:
             # If so, redirect the user to their account page or dashboard
-            return request.redirect("/my2/dashboard")
+            return request.redirect("/my2/dashboard/")
 
         # If the user is not logged in, execute the original Odoo logic for login
         return super().web_login(*args, **kw)


### PR DESCRIPTION
In this PR I redirected the home page (that were accessed either with clicking on compassion logo or logging out)  to 
- my2/dashboard if the user is logged in
- web/login if there's no logged in user

#### Implementation : 
I added a python controller to achieve that.
I first tried to achieve this using xml template inheritance. After spending quite some time on it I found python controller solution very convenient. Let me know if it's a good practice or whether it has to be done through xml :) 
