### PR TITLE
T2758 Use the new error toast on sponsorships page

### DIFF
--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -150,13 +150,14 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             }
                         }.bind(this)
                     )
-                    .guardedCatch(
+                    .catch(
                         function (error) {
                             // Re-enable buttons and remove spinner in case of error
                             this.$(".btn").prop("disabled", false);
                             $spinner.remove();
+                            if (error.event) error.event.preventDefault();
                             // Display error toast
-                            ToastService.error(error.message);
+                            ToastService.error(error.message.data && error.message.data.message);
                         }.bind(this)
                     );
             },
@@ -261,12 +262,14 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             this.$(".btn").prop("disabled", false);
                         }.bind(this)
                     )
-                    .guardedCatch(
+                    .catch(
                         function (error) {
-                            // Re-enable buttons in case of error
+                            // Re-enable buttons and remove spinner in case of error
                             this.$(".btn").prop("disabled", false);
+                            $spinner.remove();
+                            if (error.event) error.event.preventDefault();
                             // Display error toast
-                            ToastService.error(error.message);
+                            ToastService.error(error.message.data && error.message.data.message);
                         }.bind(this)
                     );
             },

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -10,6 +10,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
         var publicWidget = require("web.public.widget");
         var rpc = require("web.rpc");
 
+        const ToastService = require("my_compassion.toast_service");
+        const _t = require("web.core")._t;
+
         publicWidget.registry.Sponsorships = publicWidget.Widget.extend({
             selector: ".sponsorships-body-container",
 
@@ -148,10 +151,12 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         }.bind(this)
                     )
                     .guardedCatch(
-                        function () {
+                        function (error) {
                             // Re-enable buttons and remove spinner in case of error
                             this.$(".btn").prop("disabled", false);
                             $spinner.remove();
+                            // Display error toast
+                            ToastService.error(error.message);
                         }.bind(this)
                     );
             },
@@ -257,9 +262,11 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         }.bind(this)
                     )
                     .guardedCatch(
-                        function () {
+                        function (error) {
                             // Re-enable buttons in case of error
                             this.$(".btn").prop("disabled", false);
+                            // Display error toast
+                            ToastService.error(error.message);
                         }.bind(this)
                     );
             },

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -71,6 +71,22 @@ document.addEventListener("DOMContentLoaded", function (event) {
             },
 
             /**
+             * Handles RPC errors by displaying the my_compassion2 error toast.
+             *
+             * @private
+             * @param {Object} error The error object from .catch.
+             * @param {jQuery} [$spinner] Optional spinner element to remove.
+             */
+            _handleError: function (error, $spinner) {
+                this.$(".btn").prop("disabled", false);
+                if ($spinner) $spinner.remove();
+                if (error.event) error.event.preventDefault();
+
+                // Display error toast
+                ToastService.error(error.message.data && error.message.data.message);
+            },
+
+            /**
              * Fetches and displays the next batch of sponsorships from the backend.
              * @private
              */
@@ -150,16 +166,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             }
                         }.bind(this)
                     )
-                    .catch(
-                        function (error) {
-                            // Re-enable buttons and remove spinner in case of error
-                            this.$(".btn").prop("disabled", false);
-                            $spinner.remove();
-                            if (error.event) error.event.preventDefault();
-                            // Display error toast
-                            ToastService.error(error.message.data && error.message.data.message);
-                        }.bind(this)
-                    );
+                    .catch((error) => this._handleError(error, $spinner));
             },
 
             /**
@@ -262,16 +269,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             this.$(".btn").prop("disabled", false);
                         }.bind(this)
                     )
-                    .catch(
-                        function (error) {
-                            // Re-enable buttons and remove spinner in case of error
-                            this.$(".btn").prop("disabled", false);
-                            $spinner.remove();
-                            if (error.event) error.event.preventDefault();
-                            // Display error toast
-                            ToastService.error(error.message.data && error.message.data.message);
-                        }.bind(this)
-                    );
+                    .catch((error) => this._handleError(error, $spinner));
             },
         });
 


### PR DESCRIPTION
Implemented error handling on the `my2/sponsorships` page to align with the new theme.

**Changes:**
- Add the new `ToastService` and display the error through it
- Suppressed the default Odoo notification
- Refactored error handling into a private method (`_handleError`) to improve modularity and adhere to the DRY principle