### PR TITLE
T2756 remove header menu from login page

### DIFF
--- a/my_compassion/templates/pages/my2_login_template.xml
+++ b/my_compassion/templates/pages/my2_login_template.xml
@@ -5,7 +5,6 @@
     <template id="my2_login_template" inherit_id="website.login_layout" website_id="my_compassion.my2_website">
         <xpath expr="t" position="replace">
             <t t-set="no_footer" t-value="True" />
-            <t t-set="no_header" t-value="True" />
             <!-- Add css to the page -->
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_login.css" />
             <t t-call="website.layout">

--- a/my_compassion/templates/pages/my2_login_template.xml
+++ b/my_compassion/templates/pages/my2_login_template.xml
@@ -5,6 +5,7 @@
     <template id="my2_login_template" inherit_id="website.login_layout" website_id="my_compassion.my2_website">
         <xpath expr="t" position="replace">
             <t t-set="no_footer" t-value="True" />
+            <t t-set="no_header" t-value="True" />
             <!-- Add css to the page -->
             <link rel="stylesheet" href="/my_compassion/static/src/css/my2_login.css" />
             <t t-call="website.layout">

--- a/my_compassion/views/my2_header_menu.xml
+++ b/my_compassion/views/my2_header_menu.xml
@@ -37,8 +37,8 @@
         name="Custom Header Cart Link Redirect"
     >
         <!-- Hide the cart when user is not logged in -->
-        <xpath expr="//t[@t-set='show_cart']" position="replace">
-            <t t-set="show_cart" t-value="request.session.uid" />
+        <xpath expr="//t[@t-set='show_cart']" position="attributes">
+            <attribute name="t-value">request.session.uid</attribute>
         </xpath>
         <!-- Modify the behavior of the base Odoo cart for custom redirection and design -->
         <xpath expr="//a[@href='/shop/cart']" position="attributes">

--- a/my_compassion/views/my2_header_menu.xml
+++ b/my_compassion/views/my2_header_menu.xml
@@ -36,6 +36,10 @@
         inherit_id="website_sale.header_cart_link"
         name="Custom Header Cart Link Redirect"
     >
+        <!-- Hide the cart when user is not logged in -->
+        <xpath expr="//t[@t-set='show_cart']" position="replace">
+            <t t-set="show_cart" t-value="request.session.uid" />
+        </xpath>
         <!-- Modify the behavior of the base Odoo cart for custom redirection and design -->
         <xpath expr="//a[@href='/shop/cart']" position="attributes">
             <attribute name="href">/my2/gift-package</attribute>

--- a/my_compassion/views/my2_header_menu.xml
+++ b/my_compassion/views/my2_header_menu.xml
@@ -2,8 +2,8 @@
 <odoo>
     <template id="my_compassion_dynamic_menu" inherit_id="website.template_header_default">
         <xpath expr="//div[@id='top_menu_collapse']/*[1]" position="before">
-            <ul class="navbar-nav">
-                <t t-if="request.session.uid">
+            <t t-if="request.session.uid">
+                <ul class="navbar-nav">
                     <t t-set="partner" t-value="request.env.user.partner_id" />
                     <li class="nav-item">
                         <a class="nav-link" href="/my2/dashboard">Home</a>
@@ -27,8 +27,8 @@
                             <a class="nav-link" href="/my2/donations">My donations</a>
                         </li>
                     </t>
-                </t>
-            </ul>
+                </ul>
+            </t>
         </xpath>
     </template>
     <template

--- a/my_compassion/views/my2_header_menu.xml
+++ b/my_compassion/views/my2_header_menu.xml
@@ -3,28 +3,30 @@
     <template id="my_compassion_dynamic_menu" inherit_id="website.template_header_default">
         <xpath expr="//div[@id='top_menu_collapse']/*[1]" position="before">
             <ul class="navbar-nav">
-                <t t-set="partner" t-value="request.env.user.partner_id" />
-                <li class="nav-item">
-                    <a class="nav-link" href="/my2/dashboard">Home</a>
-                </li>
-                <t t-if="partner.is_sponsor">
+                <t t-if="request.session.uid">
+                    <t t-set="partner" t-value="request.env.user.partner_id" />
                     <li class="nav-item">
-                        <a class="nav-link" href="/my2/children">My sponsorships</a>
+                        <a class="nav-link" href="/my2/dashboard">Home</a>
                     </li>
+                    <t t-if="partner.is_sponsor">
+                        <li class="nav-item">
+                            <a class="nav-link" href="/my2/children">My sponsorships</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/my2/children/letters">Letters</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/my2/children/letters/new">Write a letter</a>
+                        </li>
+                    </t>
                     <li class="nav-item">
-                        <a class="nav-link" href="/my2/children/letters">Letters</a>
+                        <a class="nav-link" href="/my2/gifts">Make a gift</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/my2/children/letters/new">Write a letter</a>
-                    </li>
-                </t>
-                <li class="nav-item">
-                    <a class="nav-link" href="/my2/gifts">Make a gift</a>
-                </li>
-                <t t-if="partner.is_donor">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/my2/donations">My donations</a>
-                    </li>
+                    <t t-if="partner.is_donor">
+                        <li class="nav-item">
+                            <a class="nav-link" href="/my2/donations">My donations</a>
+                        </li>
+                    </t>
                 </t>
             </ul>
         </xpath>


### PR DESCRIPTION
In this PR, I removed the header menu from the login page, since users cannot access other pages unless they are logged in. Once logged in, the header menu is available as before.

### Logic:
I wrapped the header menu items in <t t-if="request.session.uid"> to hide them for unauthenticated users.