### PR TITLE
T2757 add message when letter inbox is empty

### DIFF
--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -317,18 +317,19 @@
                         </t>
                     </div>
                 </t>
-
                 <t t-else="">
-                        <div class="container text-center mt-5">
-                             <t t-call="theme_compassion_2025.TitleComponent">
-                                 <t t-set="title_size" t-value="'sm'" />
-                        <t t-set="title_content" t-value="'No letters found'" />
-                        <t t-set="color" t-value="'core-blue'" />
-                        <t t-set="show_underline" t-value="false" />
-                        <t t-set="underline_color" t-value="'low-yellow'" />
-                        <t t-set="description" t-value="'We couldn\'t find any letters. Why not start writing a letter?'" />
-                    </t>
-
+                    <div class="container text-center mt-5">
+                        <t t-call="theme_compassion_2025.TitleComponent">
+                            <t t-set="title_size" t-value="'sm'" />
+                            <t t-set="title_content" t-value="'No letters found'" />
+                            <t t-set="color" t-value="'core-blue'" />
+                            <t t-set="show_underline" t-value="false" />
+                            <t t-set="underline_color" t-value="'low-yellow'" />
+                            <t
+                                t-set="description"
+                                t-value="'We couldn\'t find any letters. Why not start writing a letter?'"
+                            />
+                        </t>
                         <t t-call="theme_compassion_2025.ThemedButtonComponent">
                             <t t-set="variant" t-value="'default'" />
                             <t t-set="variation" t-value="'filled'" />

--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -265,7 +265,7 @@
                     </div>
                 </div>
                 <!-- Letters -->
-                <t t-if="letter">
+                <t t-if="letters">
                     <div class="container-content d-flex flex-column align-items-center mt-4">
                         <div class="w-100 d-flex flex-column">
                             <div class="row justify-content-center">

--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -280,7 +280,7 @@
                         </div>
                     </div>
                     <!-- Buttons for changing page -->
-                    <div tclass="d-flex justify-content-center align-items-center mt-3 mb-5">
+                    <div class="d-flex justify-content-center align-items-center mt-3 mb-5">
                         <!-- Prev -->
                         <t t-if="current_page > 1">
                             <a id="prevPageBtn">

--- a/my_compassion/templates/pages/my2_child_letters.xml
+++ b/my_compassion/templates/pages/my2_child_letters.xml
@@ -261,60 +261,86 @@
                         </div>
                     </div>
                 </div>
-                <!-- Letters -->
-                <div class="container-content d-flex flex-column align-items-center mt-4">
-                    <div class="w-100 d-flex flex-column">
-                        <div class="row justify-content-center">
-                            <t t-foreach="letters" t-as="letter" t-foreach-index="i">
-                                <div
-                                    class="col-12 col-md-6 col-lg-4 my-3 letter-card"
-                                    t-att-data-create_date="letter.create_date"
-                                    t-att-data-type="letter.direction"
-                                    t-att-data-index="i"
-                                >
-                                    <t t-call="my_compassion.my2_letter_card_component" />
-                                </div>
-                            </t>
+                <t t-if="letters">
+                    <!-- Letters -->
+                    <div class="container-content d-flex flex-column align-items-center mt-4">
+                        <div class="w-100 d-flex flex-column">
+                            <div class="row justify-content-center">
+                                <t t-foreach="letters" t-as="letter" t-foreach-index="i">
+                                    <div
+                                        class="col-12 col-md-6 col-lg-4 my-3 letter-card"
+                                        t-att-data-create_date="letter.create_date"
+                                        t-att-data-type="letter.direction"
+                                        t-att-data-index="i"
+                                    >
+                                        <t t-call="my_compassion.my2_letter_card_component" />
+                                    </div>
+                                </t>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <!-- Buttons for changing page -->
-                <div class="d-flex justify-content-center align-items-center mt-3 mb-5">
-                    <!-- Prev -->
-                    <t t-if="current_page > 1">
-                        <a id="prevPageBtn">
-                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                                <t t-set="variation" t-value="'hollow'" />
-                                <t t-set="color" t-value="'mid-blue'" />
-                                <t t-set="text_color" t-value="'low-black'" />
-                                <t t-set="variant" t-value="'compact'" />
-                                <t t-set="label" t-value="'Prev'" />
-                            </t>
-                        </a>
+                    <!-- Buttons for changing page -->
+                    <div tclass="d-flex justify-content-center align-items-center mt-3 mb-5">
+                        <!-- Prev -->
+                        <t t-if="current_page > 1">
+                            <a id="prevPageBtn">
+                                <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                                    <t t-set="variation" t-value="'hollow'" />
+                                    <t t-set="color" t-value="'mid-blue'" />
+                                    <t t-set="text_color" t-value="'low-black'" />
+                                    <t t-set="variant" t-value="'compact'" />
+                                    <t t-set="label" t-value="'Prev'" />
+                                </t>
+                            </a>
+                        </t>
+                        <!-- Page indicator -->
+                        <span id="pageIndicator" class="p-2">
+                            Page
+                            <t t-esc="current_page" />
+                            of
+                            <t t-esc="total_pages" />
+                        </span>
+                        <!-- Next -->
+                        <t t-if="current_page &lt; total_pages">
+                            <a id="nextPageBtn">
+                                <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                                    <t t-set="variation" t-value="'hollow'" />
+                                    <t t-set="color" t-value="'mid-blue'" />
+                                    <t t-set="text_color" t-value="'low-black'" />
+                                    <t t-set="variant" t-value="'compact'" />
+                                    <t t-set="label" t-value="'Next'" />
+                                </t>
+                            </a>
+                        </t>
+                        <t t-else="">
+                            <span class="disabled ps-3">Next</span>
+                        </t>
+                    </div>
+                </t>
+
+                <t t-else="">
+                        <div class="container text-center mt-5">
+                             <t t-call="theme_compassion_2025.TitleComponent">
+                                 <t t-set="title_size" t-value="'sm'" />
+                        <t t-set="title_content" t-value="'No letters found'" />
+                        <t t-set="color" t-value="'core-blue'" />
+                        <t t-set="show_underline" t-value="false" />
+                        <t t-set="underline_color" t-value="'low-yellow'" />
+                        <t t-set="description" t-value="'We couldn\'t find any letters. Why not start writing a letter?'" />
                     </t>
-                    <!-- Page indicator -->
-                    <span id="pageIndicator" class="p-2">
-                        Page
-                        <t t-esc="current_page" />
-                        of
-                        <t t-esc="total_pages" />
-                    </span>
-                    <!-- Next -->
-                    <t t-if="current_page &lt; total_pages">
-                        <a id="nextPageBtn">
-                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                                <t t-set="variation" t-value="'hollow'" />
-                                <t t-set="color" t-value="'mid-blue'" />
-                                <t t-set="text_color" t-value="'low-black'" />
-                                <t t-set="variant" t-value="'compact'" />
-                                <t t-set="label" t-value="'Next'" />
-                            </t>
-                        </a>
-                    </t>
-                    <t t-else="">
-                        <span class="disabled ps-3">Next</span>
-                    </t>
-                </div>
+
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variant" t-value="'default'" />
+                            <t t-set="variation" t-value="'filled'" />
+                            <t t-set="label" t-value="'Write a letter to a child'" />
+                            <t t-set="icon" t-value="'pictogram-letter-writing'" />
+                            <t t-set="color" t-value="'core-blue'" />
+                            <t t-set="icon_color" t-value="'low-yellow'" />
+                            <t t-set="text_color" t-value="'pure-white'" />
+                            <t t-set="href" t-value="'/my2/children/letters/new'" />
+                        </t>
+                    </div>
+                </t>
             </div>
         </t>
     </template>


### PR DESCRIPTION
This PR adds an "empty state" message that is displayed when the letter inbox is empty.

This new section includes a title, a short description, and a "Call to Action" button that links to /my2/children/letters/new to encourage the user to write a letter. It also hides the pagination when no letters are found.

See screenshot below.

<img width="1839" height="575" alt="image" src="https://github.com/user-attachments/assets/813a4f4b-ab88-49bf-b626-64d926998647" />

<img width="626" height="553" alt="image" src="https://github.com/user-attachments/assets/cadd505d-9361-4fe2-b81b-53f113cec277" />

