### PR TITLE
T2777 child gifts should not have the monthly possibility

### DIFF
--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -348,6 +348,8 @@ class MyCompassionDonationsController(CustomerPortal):
             frequency = "one_time"
         else:
             frequency = post.get("frequency")
+            if frequency not in ("one_time", "monthly"):
+                raise BadRequest("A valid frequency is required for this type of donation.")
 
         product = product_template.product_variant_id
         order_line_fields = {

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -349,7 +349,9 @@ class MyCompassionDonationsController(CustomerPortal):
         else:
             frequency = post.get("frequency")
             if frequency not in ("one_time", "monthly"):
-                raise BadRequest("A valid frequency is required for this type of donation.")
+                raise BadRequest(
+                    "A valid frequency is required for this type of donation."
+                )
 
         product = product_template.product_variant_id
         order_line_fields = {

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -343,8 +343,11 @@ class MyCompassionDonationsController(CustomerPortal):
                 raise BadRequest()
             price = quantity * product_template.list_price
 
-        # Get frequency
-        frequency = post.get("frequency")
+        # Get frequency and force one_time for gifts
+        if product_template.my_compassion_donation_type == "gift":
+            frequency = "one_time"
+        else:
+            frequency = post.get("frequency")
 
         product = product_template.product_variant_id
         order_line_fields = {

--- a/my_compassion/templates/components/my2_donation_form.xml
+++ b/my_compassion/templates/components/my2_donation_form.xml
@@ -63,7 +63,10 @@
                 <t t-set="underline_color" t-value="'low-yellow'" />
             </t>
             <!-- DONATION FREQUENCY -->
-            <t t-if="product.my_compassion_donation_type != 'gift'" t-call="theme_compassion_2025.ToggleButtonComponent">
+            <t
+                t-if="product.my_compassion_donation_type != 'gift'"
+                t-call="theme_compassion_2025.ToggleButtonComponent"
+            >
                 <t t-set="name" t-valuef="'#{base_name}_frequency'" />
                 <t
                     t-set="options"

--- a/my_compassion/templates/components/my2_donation_form.xml
+++ b/my_compassion/templates/components/my2_donation_form.xml
@@ -63,7 +63,7 @@
                 <t t-set="underline_color" t-value="'low-yellow'" />
             </t>
             <!-- DONATION FREQUENCY -->
-            <t t-call="theme_compassion_2025.ToggleButtonComponent">
+            <t t-if="product.my_compassion_donation_type != 'gift'" t-call="theme_compassion_2025.ToggleButtonComponent">
                 <t t-set="name" t-valuef="'#{base_name}_frequency'" />
                 <t
                     t-set="options"


### PR DESCRIPTION
In this PR, I removed the possibility to send a gift monthly.

### Details:
- **XML:** Hidden the frequency ToggleButton for gifts (it remains visible for funds).
- **Python:** Enforced `one_time` frequency directly in the backend controller. It could also be done in the xml view but it was the simplest solution (no need to change front-end logic)