### PR TITLE
[2785] FIX Together scss highlighting for checked cards

### DIFF
--- a/theme_crowdfunding/static/src/scss/custom.scss
+++ b/theme_crowdfunding/static/src/scss/custom.scss
@@ -625,7 +625,7 @@ footer {
 }
 
 .card-input-element:checked + .card {
-  background-color: lighten($blue-compassion, 50%) !important;
+  background-color: lighten($blue-compassion, 35%) !important;
   transition: background-color 0.3s;
 }
 


### PR DESCRIPTION
### Problem
On the Together platform, when a user selects a donation amount or donation goal card, there was no clear visual feedback. The selected state was not noticeable because the checked background color defined in `custom.scss` from `theme_crowdfunding` was too light and very close to white, making it indistinguishable from the unselected state.

### Solution:
Updated the background color for the checked state to a  darker shade, providing clear visual distinction when a card is selected.

### Result:
<img width="1396" height="1007" alt="Screenshot from 2025-11-20 08-24-27" src="https://github.com/user-attachments/assets/98956d8a-ff30-4563-88fc-5f24a4f28837" />
<img width="1499" height="663" alt="Screenshot from 2025-11-20 08-23-56" src="https://github.com/user-attachments/assets/891630d1-24ce-4f81-9a6a-3e65ef7f56be" />

