### PR TITLE
T2780 replace child image called from ci api to image in filestore

### DIFF
--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -25,7 +25,7 @@
                 <img
                     class="rounded-circle img-fluid mb-2"
                     t-attf-src="/web/image/compassion.child/{{child.id}}/portrait"
-                    alt="Child image"
+                    t-attf-alt="Photo of #{child.preferred_name}"
                 />
                 <!-- Child name -->
                 <div class="h2 mb-0">

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -22,7 +22,11 @@
         <div class="children-card text-center mb-3 mt-3">
             <div class="p-4 d-flex flex-column align-items-center bg-high-eggshell">
                 <!-- Child Image -->
-                <img class="rounded-circle img-fluid mb-2" t-attf-src="/web/image/compassion.child/{{child.id}}/portrait" alt="Child image" />
+                <img
+                    class="rounded-circle img-fluid mb-2"
+                    t-attf-src="/web/image/compassion.child/{{child.id}}/portrait"
+                    alt="Child image"
+                />
                 <!-- Child name -->
                 <div class="h2 mb-0">
                     <t t-esc="child.preferred_name" />

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -22,10 +22,7 @@
         <div class="children-card text-center mb-3 mt-3">
             <div class="p-4 d-flex flex-column align-items-center bg-high-eggshell">
                 <!-- Child Image -->
-                <img class="rounded-circle img-fluid mb-2" t-att-src="child.image_url" alt="Child image" />
-                <!-- TODO: maybe replace src with local image?
-                     t-attf-src="/web/image/compassion.child/{{child.id}}/portrait"
-                -->
+                <img class="rounded-circle img-fluid mb-2" t-attf-src="/web/image/compassion.child/{{child.id}}/portrait" alt="Child image" />
                 <!-- Child name -->
                 <div class="h2 mb-0">
                     <t t-esc="child.preferred_name" />


### PR DESCRIPTION
In this PR I updated the child image source in the sponsorships page (defined in `my2_children_card component`). It now retrieves the image from the local Odoo filestore (via `/web/image/compassion.child/...`) instead of the external `image_url` endpoint, aligning it with the children detail page behavior.