### PR TITLE
T2794 Impact-trip-registration-fee-is-included-in-the-barometer

### DIFF
--- a/website_event_compassion/models/event_registration.py
+++ b/website_event_compassion/models/event_registration.py
@@ -191,6 +191,7 @@ class EventRegistration(models.Model):
                         ("payment_state", "=", "paid"),
                         ("event_id", "=", compassion_event.id),
                         ("contract_id", "=", False),
+                        ("account_id.user_type_id.name", "=", "Income"),
                     ]
                 )
             )


### PR DESCRIPTION
## Summary 
This PR updates the filters used to compute the __amount_raised__ by a partner. 
The funds received to support the partner are in an account with user_type_id_.name = "Income" while the registration fee are in another one ("Bilan : Autres créances" instead of "Income"). 
![download (1)](https://github.com/user-attachments/assets/56d4ffe9-a64b-4f1f-a708-11bce7a2ba21)



