### PR TITLE
T2800 Payer only sponsorships should not access letter writing page

### DIFF
--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -172,6 +172,9 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
     )
     def my2_render_new_letter_page(self, **kwargs):
         partner = request.env.user.partner_id
+        if not partner.is_writer:
+            return request.redirect("/my2/children/")
+
         child_id = self._safe_int(kwargs.get("child_id"), None)
         child = request.env["compassion.child"].browse(child_id)
         sponsorships = partner.sponsorship_ids.filtered("child_id.can_i_write_letter")

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -12,6 +12,12 @@ class Partner(models.Model):
 
     # True if the partner has ever made a donation
     is_donor = fields.Boolean(compute="_compute_is_donor", compute_sudo=True)
+    # True if the partner can write a letter to a sponsored child
+    is_writer = fields.Boolean(
+        string="Is letter writer",
+        compute="_compute_is_writer",
+        compute_sudo=True,
+    )
 
     user_login = fields.Char(
         string="MyCompassion login",
@@ -93,3 +99,18 @@ class Partner(models.Model):
         donor_ids = {data["partner_id"][0] for data in donors_data}
         for partner in self:
             partner.is_donor = partner.id in donor_ids
+
+    # TODO what about the info_all ? Should I put the fully managed ( using hte ) ?
+    def _compute_is_writer(self):
+        for partner in self:
+            sponsorships = self.env["recurring.contract"].search(
+                [
+                    ("correspondent_id", "=", partner.id),
+                    ("can_write_letter", "=", True),
+                    ("is_active", "=", True),
+                    ("child_id", "!=", False),
+                ],
+            )
+            partner.is_writer = bool(sponsorships) or (
+                partner.is_sponsor and partner.portal_sponsorships == "all_info"
+            )

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -100,9 +100,18 @@ class Partner(models.Model):
         for partner in self:
             partner.is_donor = partner.id in donor_ids
 
-    # TODO what about the info_all ? Should I put the fully managed ( using hte ) ?
     def _compute_is_writer(self):
+        """
+        Compute whether the partner can write letters to sponsored children.
+        """
         for partner in self:
-            partner.is_writer = any(
-                partner.sponsorship_ids.mapped("child_id").mapped("can_i_write_letter")
+            partner.is_writer = bool(
+                partner.sponsorship_ids.filtered_domain(
+                    [
+                        ("can_write_letter", "=", True),
+                        "|",
+                        ("partner_id.portal_sponsorships", "=", "all_info"),
+                        ("correspondent_id", "=", partner.id),
+                    ]
+                )
             )

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -103,14 +103,7 @@ class Partner(models.Model):
     # TODO what about the info_all ? Should I put the fully managed ( using hte ) ?
     def _compute_is_writer(self):
         for partner in self:
-            sponsorships = self.env["recurring.contract"].search(
-                [
-                    ("correspondent_id", "=", partner.id),
-                    ("can_write_letter", "=", True),
-                    ("is_active", "=", True),
-                    ("child_id", "!=", False),
-                ],
-            )
-            partner.is_writer = bool(sponsorships) or (
-                partner.is_sponsor and partner.portal_sponsorships == "all_info"
-            )
+            partner.is_writer= any(partner.sponsorship_ids.mapped("child_id").mapped("can_i_write_letter"))
+
+
+

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -103,7 +103,6 @@ class Partner(models.Model):
     # TODO what about the info_all ? Should I put the fully managed ( using hte ) ?
     def _compute_is_writer(self):
         for partner in self:
-            partner.is_writer= any(partner.sponsorship_ids.mapped("child_id").mapped("can_i_write_letter"))
-
-
-
+            partner.is_writer = any(
+                partner.sponsorship_ids.mapped("child_id").mapped("can_i_write_letter")
+            )

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -97,18 +97,17 @@ Page: My Compassion 2 Dashboard Page
                     </t>
                 </t>
                 <t t-if="partner.is_writer">
-                <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                    <t t-set="variant" t-value="'default'" />
-                    <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label">Write to Your Child</t>
-                    <t t-set="icon" t-value="'pictogram-letter-writing'" />
-                    <t t-set="color" t-value="'core-blue'" />
-                    <t t-set="icon_color" t-value="'low-yellow'" />
-                    <t t-set="text_color" t-value="'pure-white'" />
-                    <t t-set="href" t-value="'/my2/children/letters/new'" />
-                </t>
+                    <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                        <t t-set="variant" t-value="'default'" />
+                        <t t-set="variation" t-value="'filled'" />
+                        <t t-set="label">Write to Your Child</t>
+                        <t t-set="icon" t-value="'pictogram-letter-writing'" />
+                        <t t-set="color" t-value="'core-blue'" />
+                        <t t-set="icon_color" t-value="'low-yellow'" />
+                        <t t-set="text_color" t-value="'pure-white'" />
+                        <t t-set="href" t-value="'/my2/children/letters/new'" />
                     </t>
-
+                </t>
             </t>
             <!-- If an ex-sponsor, creates a button to see old sponsorships  -->
             <t t-if="partner.is_ex_sponsor">

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -95,15 +95,17 @@ Page: My Compassion 2 Dashboard Page
                         />
                     </t>
                 </t>
-                <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                    <t t-set="variant" t-value="'default'" />
-                    <t t-set="variation" t-value="'filled'" />
-                    <t t-set="label" t-value="'Write a letter to a child'" />
-                    <t t-set="icon" t-value="'pictogram-letter-writing'" />
-                    <t t-set="color" t-value="'core-blue'" />
-                    <t t-set="icon_color" t-value="'low-yellow'" />
-                    <t t-set="text_color" t-value="'pure-white'" />
-                    <t t-set="href" t-value="'/my2/children/letters/new'" />
+                <t t-if="partner.is_writer">
+                    <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                        <t t-set="variant" t-value="'default'" />
+                        <t t-set="variation" t-value="'filled'" />
+                        <t t-set="label" t-value="'Write a letter to a child'" />
+                        <t t-set="icon" t-value="'pictogram-letter-writing'" />
+                        <t t-set="color" t-value="'core-blue'" />
+                        <t t-set="icon_color" t-value="'low-yellow'" />
+                        <t t-set="text_color" t-value="'pure-white'" />
+                        <t t-set="href" t-value="'/my2/children/letters/new'" />
+                    </t>
                 </t>
             </t>
             <!-- If an ex-sponsor, creates a button to see old sponsorships  -->


### PR DESCRIPTION
## Summary 
This PR resolves technical debt that allowed a pay-only sponsor to access the letter-writing page. Additionally, it ensures the "Write a new letter" button is not shown on the dashboard if the sponsor cannot write to any of their children. 

## Solutions

1) If the sponsor tries to access the letter writing page even if all their sponsorships are _pay only_ , they are redirected to the children page. 

2) On the dashboard, show the "Write a new letter" button only if the sponsor has at least one child they can write to. 


## How to test

Here are some partner id who should not be able to write a letter to any of their children (they also have portal_sponsorships != all_info)

30353
28915
16718
22020
41068
28848
15567

One can check that the button is hidden and the redirection works.
