### PR TITLE
T2702 improve event banners with a user filter system

### DIFF
--- a/my_compassion/controllers/my2_event_banner.py
+++ b/my_compassion/controllers/my2_event_banner.py
@@ -48,6 +48,8 @@ class MyCompassionEventBannerController(http.Controller):
             ("end_date", "=", False),
             ("end_date", ">=", now),
             # Match either the full path or the path without the lang prefix
+            "|",
+            ("target_route_ids", "=", False),
             ("target_route_ids.path", "in", possible_routes),
             "|",
             ("target_partner_tags", "=", False),

--- a/my_compassion/controllers/my2_event_banner.py
+++ b/my_compassion/controllers/my2_event_banner.py
@@ -35,9 +35,10 @@ class MyCompassionEventBannerController(http.Controller):
             unprefixed_route = "/" + "/".join(path_parts[2:])
             possible_routes.append(unprefixed_route)
 
-        user = request.env.user
-        # Falls Public User (nicht eingeloggt), ist partner_id gesetzt aber category_id leer
-        user_tag_ids = user.partner_id.category_id.ids
+        if request.env.user._is_public():
+            user_tag_ids = []
+        else:
+            user_tag_ids = request.env.user.partner_id.sudo().category_id.ids
 
         now = fields.Datetime.now()
         domain = [
@@ -49,8 +50,8 @@ class MyCompassionEventBannerController(http.Controller):
             # Match either the full path or the path without the lang prefix
             ("target_route_ids.path", "in", possible_routes),
             "|",
-            ("limit_to_tag_ids", "=", False),
-            ("limit_to_tag_ids", "in", user_tag_ids)
+            ("target_partner_tags", "=", False),
+            ("target_partner_tags", "in", user_tag_ids)
         ]
 
         banners = (

--- a/my_compassion/controllers/my2_event_banner.py
+++ b/my_compassion/controllers/my2_event_banner.py
@@ -35,6 +35,10 @@ class MyCompassionEventBannerController(http.Controller):
             unprefixed_route = "/" + "/".join(path_parts[2:])
             possible_routes.append(unprefixed_route)
 
+        user = request.env.user
+        # Falls Public User (nicht eingeloggt), ist partner_id gesetzt aber category_id leer
+        user_tag_ids = user.partner_id.category_id.ids
+
         now = fields.Datetime.now()
         domain = [
             ("is_active", "=", True),
@@ -44,6 +48,9 @@ class MyCompassionEventBannerController(http.Controller):
             ("end_date", ">=", now),
             # Match either the full path or the path without the lang prefix
             ("target_route_ids.path", "in", possible_routes),
+            "|",
+            ("limit_to_tag_ids", "=", False),
+            ("limit_to_tag_ids", "in", user_tag_ids)
         ]
 
         banners = (

--- a/my_compassion/controllers/my2_event_banner.py
+++ b/my_compassion/controllers/my2_event_banner.py
@@ -52,8 +52,8 @@ class MyCompassionEventBannerController(http.Controller):
             ("target_route_ids", "=", False),
             ("target_route_ids.path", "in", possible_routes),
             "|",
-            ("target_partner_tags", "=", False),
-            ("target_partner_tags", "in", user_tag_ids),
+            ("target_partner_tag_ids", "=", False),
+            ("target_partner_tag_ids", "in", user_tag_ids),
         ]
 
         banners = (

--- a/my_compassion/controllers/my2_event_banner.py
+++ b/my_compassion/controllers/my2_event_banner.py
@@ -51,7 +51,7 @@ class MyCompassionEventBannerController(http.Controller):
             ("target_route_ids.path", "in", possible_routes),
             "|",
             ("target_partner_tags", "=", False),
-            ("target_partner_tags", "in", user_tag_ids)
+            ("target_partner_tags", "in", user_tag_ids),
         ]
 
         banners = (

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -105,14 +105,13 @@ class EventBanner(models.Model):
     target_route_ids = fields.Many2many(
         "my2.website.route",
         string="Target Pages",
-        help="Select the pages where this banner should be visible.",
+        help="If pages are selected, the banner is only visible on those pages. If empty, it is visible on all pages.",
     )
 
     target_partner_tags = fields.Many2many(
         comodel_name="res.partner.category",
         string="Target Contact Tags",
-        help="If selected, the banner is only visible to users who have at least "
-        "one of these tags. If empty, it is visible to everyone.",
+        help="If tags are selected, the banner is only visible to users having at least one of these tags. If empty, it is visible to everyone.",
     )
 
     def name_get(self):

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -105,13 +105,15 @@ class EventBanner(models.Model):
     target_route_ids = fields.Many2many(
         "my2.website.route",
         string="Target Pages",
-        help="If pages are selected, the banner is only visible on those pages. If empty, it is visible on all pages.",
+        help="If pages are selected, the banner is only visible on those pages. "
+             "If empty, it is visible on all pages.",
     )
 
     target_partner_tags = fields.Many2many(
         comodel_name="res.partner.category",
         string="Target Contact Tags",
-        help="If tags are selected, the banner is only visible to users having at least one of these tags. If empty, it is visible to everyone.",
+        help="If tags are selected, the banner is only visible to users having "
+             "at least one of these tags. If empty, it is visible to everyone.",
     )
 
     def name_get(self):

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -106,14 +106,14 @@ class EventBanner(models.Model):
         "my2.website.route",
         string="Target Pages",
         help="If pages are selected, the banner is only visible on those pages. "
-             "If empty, it is visible on all pages.",
+        "If empty, it is visible on all pages.",
     )
 
     target_partner_tags = fields.Many2many(
         comodel_name="res.partner.category",
         string="Target Contact Tags",
         help="If tags are selected, the banner is only visible to users having "
-             "at least one of these tags. If empty, it is visible to everyone.",
+        "at least one of these tags. If empty, it is visible to everyone.",
     )
 
     def name_get(self):

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -109,7 +109,7 @@ class EventBanner(models.Model):
         "If empty, it is visible on all pages.",
     )
 
-    target_partner_tags = fields.Many2many(
+    target_partner_tag_ids = fields.Many2many(
         comodel_name="res.partner.category",
         string="Target Contact Tags",
         help="If tags are selected, the banner is only visible to users having "

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -111,7 +111,8 @@ class EventBanner(models.Model):
     target_partner_tags = fields.Many2many(
         comodel_name="res.partner.category",
         string="Target Contact Tags",
-        help="If selected, the banner is only visible to users who have at least one of these tags. If empty, it is visible to everyone.",
+        help="If selected, the banner is only visible to users who have at least "
+        "one of these tags. If empty, it is visible to everyone.",
     )
 
     def name_get(self):

--- a/my_compassion/models/my2_event_banner.py
+++ b/my_compassion/models/my2_event_banner.py
@@ -108,6 +108,12 @@ class EventBanner(models.Model):
         help="Select the pages where this banner should be visible.",
     )
 
+    target_partner_tags = fields.Many2many(
+        comodel_name="res.partner.category",
+        string="Target Contact Tags",
+        help="If selected, the banner is only visible to users who have at least one of these tags. If empty, it is visible to everyone.",
+    )
+
     def name_get(self):
         """
         Generates the display name for the banners.

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -26,7 +26,7 @@ Page: My Compassion 2 Dashboard Page
         <t t-call="website.layout">
             <div class="container">
                 <!-- BANNER -->
-                <div class="dashboard-banner d-none d-lg-block mt-4">
+                <div class="dashboard-banner d-none d-lg-block">
                     <div class="position-absolute m-5 pl-5 pt-2">
                         <h1 class="text-pure-white">
                             Welcome to

--- a/my_compassion/templates/pages/my2_gifts.xml
+++ b/my_compassion/templates/pages/my2_gifts.xml
@@ -24,7 +24,7 @@ Page: My Compassion 2 Gifts Page
                 <t t-set="is_gift" t-value="type == 'gift'" />
                 <t t-set="is_fund" t-value="type == 'fund'" />
                 <!-- BANNER -->
-                <div class="container-content mt-4">
+                <div class="container-content">
                     <t t-call="theme_compassion_2025.BannerComponent">
                         <t t-if="is_gift">
                             <t t-set="title">Give the Gift of Compassion</t>

--- a/my_compassion/views/my2_event_banner_views.xml
+++ b/my_compassion/views/my2_event_banner_views.xml
@@ -64,11 +64,19 @@
                     <group string="Target">
                         <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
                         <p class="text-info" colspan="2">
-                            <i class="fa fa-info-circle"/> If pages are selected, the banner is only visible on those pages. If empty, it is visible on all pages.
+                            <i class="fa fa-info-circle" />
+                            If pages are selected, the banner is only visible on those pages. If empty, it is visible on
+                            all pages.
                         </p>
-                        <field name="target_partner_tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" />
+                        <field
+                            name="target_partner_tags"
+                            widget="many2many_tags"
+                            options="{'color_field': 'color', 'no_create_edit': True}"
+                        />
                         <p class="text-info" colspan="2">
-                            <i class="fa fa-info-circle"/> If tags are selected, the banner is only visible to users having at least one of these tags. If empty, it is visible to everyone.
+                            <i class="fa fa-info-circle" />
+                            If tags are selected, the banner is only visible to users having at least one of these tags.
+                            If empty, it is visible to everyone.
                         </p>
                     </group>
                 </sheet>

--- a/my_compassion/views/my2_event_banner_views.xml
+++ b/my_compassion/views/my2_event_banner_views.xml
@@ -10,7 +10,7 @@
                 <field name="is_active" />
                 <field name="start_date" />
                 <field name="end_date" />
-                <field name="target_partner_tags" widget="many2many_tags" color="color" />
+                <field name="target_partner_tag_ids" widget="many2many_tags" color="color" />
                 <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
                 <field name="button_action_url" />
             </tree>
@@ -69,7 +69,7 @@
                             all pages.
                         </p>
                         <field
-                            name="target_partner_tags"
+                            name="target_partner_tag_ids"
                             widget="many2many_tags"
                             options="{'color_field': 'color', 'no_create_edit': True}"
                         />

--- a/my_compassion/views/my2_event_banner_views.xml
+++ b/my_compassion/views/my2_event_banner_views.xml
@@ -63,11 +63,13 @@
                     </group>
                     <group string="Target">
                         <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
-                        <field
-                            name="target_partner_tags"
-                            widget="many2many_tags"
-                            options="{'color_field': 'color', 'no_create_edit': True}"
-                        />
+                        <p class="text-info" colspan="2">
+                            <i class="fa fa-info-circle"/> If pages are selected, the banner is only visible on those pages. If empty, it is visible on all pages.
+                        </p>
+                        <field name="target_partner_tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" />
+                        <p class="text-info" colspan="2">
+                            <i class="fa fa-info-circle"/> If tags are selected, the banner is only visible to users having at least one of these tags. If empty, it is visible to everyone.
+                        </p>
                     </group>
                 </sheet>
             </form>

--- a/my_compassion/views/my2_event_banner_views.xml
+++ b/my_compassion/views/my2_event_banner_views.xml
@@ -10,7 +10,7 @@
                 <field name="is_active" />
                 <field name="start_date" />
                 <field name="end_date" />
-                <field name="target_partner_tags" widget="many2many_tags" color="color"/>
+                <field name="target_partner_tags" widget="many2many_tags" color="color" />
                 <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
                 <field name="button_action_url" />
             </tree>
@@ -63,7 +63,11 @@
                     </group>
                     <group string="Target">
                         <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
-                        <field name="target_partner_tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                        <field
+                            name="target_partner_tags"
+                            widget="many2many_tags"
+                            options="{'color_field': 'color', 'no_create_edit': True}"
+                        />
                     </group>
                 </sheet>
             </form>

--- a/my_compassion/views/my2_event_banner_views.xml
+++ b/my_compassion/views/my2_event_banner_views.xml
@@ -10,6 +10,7 @@
                 <field name="is_active" />
                 <field name="start_date" />
                 <field name="end_date" />
+                <field name="target_partner_tags" widget="many2many_tags" color="color"/>
                 <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
                 <field name="button_action_url" />
             </tree>
@@ -60,8 +61,9 @@
                             <field name="end_date" />
                         </group>
                     </group>
-                    <group string="Target Pages">
+                    <group string="Target">
                         <field name="target_route_ids" widget="many2many_tags" options="{'no_create_edit': True}" />
+                        <field name="target_partner_tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                     </group>
                 </sheet>
             </form>

--- a/theme_compassion_2025/static/src/js/_event_banner.js
+++ b/theme_compassion_2025/static/src/js/_event_banner.js
@@ -37,7 +37,7 @@ odoo.define("theme_compassion_2025.event_banner", function (require) {
             }
 
             const dismissedBanners = JSON.parse(localStorage.getItem("dismissedBanners") || "[]");
-            const $container = $("main .container").first();
+            const $container = $("main");
 
             items
                 .slice()

--- a/theme_compassion_2025/templates/components/EventBanner.xml
+++ b/theme_compassion_2025/templates/components/EventBanner.xml
@@ -23,7 +23,7 @@
     <template id="EventBannerComponent" name="Event Banner Component">
         <div
             t-att-data-id="banner.id"
-            t-attf-class="event-banner bg-#{banner.background_color.class_name} text-#{banner.text_color.class_name} mt-3 px-3 py-3 px-md-5 rounded-lg"
+            t-attf-class="event-banner bg-#{banner.background_color.class_name} text-#{banner.text_color.class_name} mt-3 mb-3 px-3 py-3 px-md-5 rounded-lg"
         >
             <div class="row no-gutters align-items-center">
                 <!-- Mobile Close Button and Pictogram Centered -->


### PR DESCRIPTION
Implemented a filtering mechanism to restrict banner visibility to specific user tags (e.g., Sponsors, Donors).

- **Model**: Added target_partner_tags field.
- **Behavior**:
     - _Empty_: Banner is shown to all users (default behavior).
     - _Selected_: Banner is restricted to users with matching tags.
- **Controller**: Updated logic to filter active banners based on the current user's partner tags.


### Odoo Backend List View:
<img width="2105" height="218" alt="image" src="https://github.com/user-attachments/assets/7a73a4fa-ef18-415a-8f25-6967d66f2dc8" />

### Odoo Backend Detail View (with description below `Target Pages`& `Target Contact Tags`) :
<img width="2555" height="749" alt="image" src="https://github.com/user-attachments/assets/3260c12b-17b0-4dba-80e9-262307050217" />

### **What else was fixed or implemented in this PR:**

* Unified the page layout by adjusting the margins on all pages to ensure consistent spacing between the content and the navbar.
* Corrected the behaviour of the *target pages* selection:
  * If **no page** is selected, the banner is shown on **all** pages.
  * If **one or more pages** are selected, the banner is shown **only** on those specific pages.
  * The same logic now also applies to user tags.
* The banner is now appended directly into the `<main>` container.
  Previously, it was appended to a div with the class `.container`, which is not present on all pages, leading to inconsistent rendering.

