### PR TITLE
[T2801] FEAT: remove "Privacy and cookies" and "FAQ" from the compass…

### DIFF
--- a/theme_compassion_2025/views/footer.xml
+++ b/theme_compassion_2025/views/footer.xml
@@ -60,31 +60,14 @@
                             <div class="d-flex flex-column flex-md-row justify-content-end col-lg-6">
                                 <div class="d-flex flex-row mb-md-0 mb-3">
                                     <a
-                                        class="mr-2 text-pure-white"
+                                        class="mr-3 text-pure-white"
                                         href="https://compassion.ch/protection-des-donnees/"
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
                                         Policies
                                     </a>
-                                    <span class="mr-2">|</span>
-                                    <a
-                                        class="mr-2 text-pure-white"
-                                        href="https://compassion.ch/protection-des-donnees/"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        Privacy and cookies
-                                    </a>
-                                    <span class="mr-2">|</span>
-                                    <a
-                                        class="text-pure-white"
-                                        href="https://compassion.ch/questions-frequentes/"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        FAQ
-                                    </a>
+                                    <span>|</span>
                                 </div>
                                 <div class="ml-0 ml-md-3 d-flex flex-row">
                                     <a

--- a/theme_compassion_2025/views/footer.xml
+++ b/theme_compassion_2025/views/footer.xml
@@ -67,7 +67,7 @@
                                     >
                                         Policies
                                     </a>
-                                    <span>|</span>
+                                    <span class="d-none d-md-inline">|</span>
                                 </div>
                                 <div class="ml-0 ml-md-3 d-flex flex-row">
                                     <a


### PR DESCRIPTION
In this PR, I removed “Privacy and cookies” and “FAQ” from the Compassion footer.

<img width="1713" height="318" alt="image" src="https://github.com/user-attachments/assets/1b18b541-fb25-4a3b-b25d-28f71840d9e7" />

<img width="515" height="412" alt="image" src="https://github.com/user-attachments/assets/d19597d7-307e-4940-99fb-f2a54089e2e3" />

