### PR TITLE
T2820 Refactor child birthday display to python controller

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -21,7 +21,7 @@ class MyCompassionChildrenController(WebsiteChild):
     def _get_formatted_birthday(self, child):
         """
         Formats the child's birthday based on the current language context.
-        Handles specific rules for EN (US/UK), FR, IT, DE and nordic languages (.
+        Handles specific rules for EN (US/UK), FR, IT, DE and nordic languages.
         """
         if not child.birthdate:
             return ""

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -7,6 +7,7 @@
 #
 ##############################################################################
 import json
+
 import babel.dates
 
 from odoo import _, http
@@ -30,31 +31,41 @@ class MyCompassionChildrenController(WebsiteChild):
         day = birthdate.day
 
         # Get localized month name
-        month = babel.dates.format_date(birthdate, format='MMMM', locale=lang_code)
+        month = babel.dates.format_date(birthdate, format="MMMM", locale=lang_code)
 
         # German, Norwegian, Danish, Finnish: Dot after day (e.g., 24. Januar)
         # Note: Swedish is excluded here as it typically uses a space (24 januari)
-        if lang_code.startswith('de') or lang_code[:2] in ['no', 'nb', 'nn', 'da', 'fi']:
+        if lang_code.startswith("de") or lang_code[:2] in [
+            "no",
+            "nb",
+            "nn",
+            "da",
+            "fi",
+        ]:
             return f"{day}. {month}"
 
         # Swedish, French, Italian: Space after day (e.g., 24 januari)
-        if lang_code.startswith('fr') or lang_code.startswith('it') or lang_code.startswith('sv'):
+        if (
+            lang_code.startswith("fr")
+            or lang_code.startswith("it")
+            or lang_code.startswith("sv")
+        ):
             # French specific: 1st is "1er"
-            if lang_code.startswith('fr') and day == 1:
+            if lang_code.startswith("fr") and day == 1:
                 return f"1er {month}"
             return f"{day} {month}"
 
         # English Logic
-        if lang_code.startswith('en'):
+        if lang_code.startswith("en"):
             # Suffix calculation
             # Special cases for 11, 12, 13.
             if 11 <= day <= 13:
-                suffix = 'th'
+                suffix = "th"
             else:
-                suffix = {1: 'st', 2: 'nd', 3: 'rd'}.get(day % 10, 'th')
+                suffix = {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
 
             # US Format: Month Day+Suffix
-            if lang_code == 'en_US':
+            if lang_code == "en_US":
                 return f"{month} {day}{suffix}"
 
             # UK/Other English: Day+Suffix Month

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -7,6 +7,7 @@
 #
 ##############################################################################
 import json
+import babel.dates
 
 from odoo import _, http
 from odoo.exceptions import AccessError
@@ -16,6 +17,52 @@ from odoo.addons.website_sponsorship.controllers.main import WebsiteChild
 
 
 class MyCompassionChildrenController(WebsiteChild):
+    def _get_formatted_birthday(self, child):
+        """
+        Formats the child's birthday based on the current language context.
+        Handles specific rules for EN (US/UK), FR, IT, DE and nordic languages (.
+        """
+        if not child.birthdate:
+            return ""
+
+        lang_code = request.env.lang
+        birthdate = child.birthdate
+        day = birthdate.day
+
+        # Get localized month name
+        month = babel.dates.format_date(birthdate, format='MMMM', locale=lang_code)
+
+        # German, Norwegian, Danish, Finnish: Dot after day (e.g., 24. Januar)
+        # Note: Swedish is excluded here as it typically uses a space (24 januari)
+        if lang_code.startswith('de') or lang_code[:2] in ['no', 'nb', 'nn', 'da', 'fi']:
+            return f"{day}. {month}"
+
+        # Swedish, French, Italian: Space after day (e.g., 24 januari)
+        if lang_code.startswith('fr') or lang_code.startswith('it') or lang_code.startswith('sv'):
+            # French specific: 1st is "1er"
+            if lang_code.startswith('fr') and day == 1:
+                return f"1er {month}"
+            return f"{day} {month}"
+
+        # English Logic
+        if lang_code.startswith('en'):
+            # Suffix calculation
+            # Special cases for 11, 12, 13.
+            if 11 <= day <= 13:
+                suffix = 'th'
+            else:
+                suffix = {1: 'st', 2: 'nd', 3: 'rd'}.get(day % 10, 'th')
+
+            # US Format: Month Day+Suffix
+            if lang_code == 'en_US':
+                return f"{month} {day}{suffix}"
+
+            # UK/Other English: Day+Suffix Month
+            return f"{day}{suffix} {month}"
+
+        # Fallback for other languages (Standard Day Month)
+        return f"{day} {month}"
+
     def _check_sponsored_child_access(self, child):
         """
         Private helper to securely fetch a sponsored child.
@@ -218,6 +265,8 @@ class MyCompassionChildrenController(WebsiteChild):
 
         records, total = self._get_timeline_records(child.id, offset, limit)
 
+        birthday_formatted = self._get_formatted_birthday(child)
+
         google_api_key = (
             request.env["ir.config_parameter"].sudo().get_param("google_maps_api_key")
         )
@@ -235,6 +284,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 "google_api_key": google_api_key,
                 "google_custom_map_id": google_custom_map_id,
                 "timezone": child.sudo().project_id.timezone,
+                "birthday_formatted": birthday_formatted,
             },
         )
 

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -33,30 +33,22 @@ class MyCompassionChildrenController(WebsiteChild):
         # Get localized month name
         month = babel.dates.format_date(birthdate, format="MMMM", locale=lang_code)
 
+        lang_prefix = lang_code[:2]
+
         # German, Norwegian, Danish, Finnish: Dot after day (e.g., 24. Januar)
         # Note: Swedish is excluded here as it typically uses a space (24 januari)
-        if lang_code.startswith("de") or lang_code[:2] in [
-            "no",
-            "nb",
-            "nn",
-            "da",
-            "fi",
-        ]:
+        if lang_prefix in {"de", "no", "nb", "nn", "da", "fi"}:
             return f"{day}. {month}"
 
         # Swedish, French, Italian: Space after day (e.g., 24 januari)
-        if (
-            lang_code.startswith("fr")
-            or lang_code.startswith("it")
-            or lang_code.startswith("sv")
-        ):
+        elif lang_prefix in {"fr", "it", "sv"}:
             # French specific: 1st is "1er"
-            if lang_code.startswith("fr") and day == 1:
+            if lang_prefix == "fr" and day == 1:
                 return f"1er {month}"
             return f"{day} {month}"
 
         # English Logic
-        if lang_code.startswith("en"):
+        elif lang_prefix == "en":
             # Suffix calculation
             # Special cases for 11, 12, 13.
             if 11 <= day <= 13:
@@ -72,7 +64,8 @@ class MyCompassionChildrenController(WebsiteChild):
             return f"{day}{suffix} {month}"
 
         # Fallback for other languages (Standard Day Month)
-        return f"{day} {month}"
+        else:
+            return f"{day} {month}"
 
     def _check_sponsored_child_access(self, child):
         """

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -109,7 +109,6 @@
                                 </t>
                             </div>
                             <!-- Child personal information -->
-
                             <div class="child-personal-information d-flex flex-column flex-grow-1 mt-md-3 ml-md-3">
                                 <t t-if="birthday_formatted">
                                     <div class="child-info-item d-flex align-items-center">

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -12,6 +12,12 @@
     Injected data:
     - compassion_child (record): The related child object.
     - access_scope (string): 'public' or 'sponsor'.
+    - records: list of items to display in the timeline
+    - has_more_records (bool): True if more timeline items exist (for infinite scroll)
+    - google_api_key (str): Google Maps API key (from ir.config_parameter)
+    - google_custom_map_id (str): Custom styled map ID (from ir.config_parameter)
+    - timezone (str): Timezone of the child's project
+    - birthday_formatted (str): Date of birth according to the specificities of the language.
 
     TO DO: inject a list of significant sponsorship events.
 -->
@@ -103,34 +109,21 @@
                                 </t>
                             </div>
                             <!-- Child personal information -->
+
                             <div class="child-personal-information d-flex flex-column flex-grow-1 mt-md-3 ml-md-3">
-                                <div class="child-info-item d-flex align-items-center">
-                                    <div class="frame bg-core-blue mr-2">
-                                        <i class="icon icon-calendar-heart02 text-pure-white m-2" />
+                                <t t-if="birthday_formatted">
+                                    <div class="child-info-item d-flex align-items-center">
+                                        <div class="frame bg-core-blue mr-2">
+                                            <i class="icon icon-calendar-heart02 text-pure-white m-2" />
+                                        </div>
+                                        <p class="child-info-text">
+                                            My birthday is
+                                            <span class="text-core-blue font-weight-bold">
+                                                <t t-esc="birthday_formatted" />
+                                            </span>
+                                        </p>
                                     </div>
-                                    <!-- TODO: Handle language changes for birthday -->
-                                    <!-- TODO: Put that in the backend (maybe) -->
-                                    <t t-set="day" t-value="compassion_child.birthdate.day" />
-                                    <t t-set="month" t-value="compassion_child.birthdate.strftime('%B')" />
-                                    <t t-set="suffix" t-value="'th'" />
-                                    <t t-if="day in [1, 21, 31]">
-                                        <t t-set="suffix" t-value="'st'" />
-                                    </t>
-                                    <t t-elif="day in [2, 22]">
-                                        <t t-set="suffix" t-value="'nd'" />
-                                    </t>
-                                    <t t-elif="day in [3, 23]">
-                                        <t t-set="suffix" t-value="'rd'" />
-                                    </t>
-                                    <p class="child-info-text">
-                                        My birthday is
-                                        <span class="text-core-blue font-weight-bold">
-                                            <t t-esc="month" />
-                                            <t t-esc="day" />
-                                            <t t-esc="suffix" />
-                                        </span>
-                                    </p>
-                                </div>
+                                </t>
                                 <div class="child-info-item d-flex align-items-center">
                                     <div class="frame bg-mid-green mr-2">
                                         <i class="icon icon-heart text-pure-white m-2" />


### PR DESCRIPTION
Moves the logic for formatting the child's birthday from the QWeb template into the Python controller to support language-specific date rules.

### Changes:

- **Controller**: Added `_get_formatted_birthday`  in `my2_children.py` to handle specific formatting rules:

  - **English**: Adds correct ordinal suffixes (st, nd, rd, th) and supports US (Month Day) ordering.
  - **French**: Handles the "1er" exception for the first of the month.
  - **German/Norwegian/Danish/Finnish:** Adds the required dot after the day (e.g., "24. Januar").
  - **Swedish/Italian:** Put a space between day and month. (For Swedish Date should appear as Day Month (no dot between, Gemini pointed this out to me, and I confirmed it with some research. See [this page](https://en.bab.la/dictionary/english-swedish/21-january) for instance).

- **Template**: Removed complex logic from my2_child_timeline.xml and replaced it with the pre-formatted birthday_formatted string.

### Results: 
<img width="641" height="114" alt="Screenshot from 2025-12-08 15-54-53" src="https://github.com/user-attachments/assets/5c49cf2e-0eab-4d6c-bde7-620f1f1aefb4" /> 

_Italian_

<img width="641" height="114" alt="Screenshot from 2025-12-08 15-54-30" src="https://github.com/user-attachments/assets/4053ed65-f9df-4670-9e25-f5c712bc9557" />

_German_

<img width="641" height="114" alt="Screenshot from 2025-12-08 15-53-53" src="https://github.com/user-attachments/assets/6d6ae87d-9357-439b-9fac-0fd4a4608e35" />

_English UK_

<img width="641" height="114" alt="Screenshot from 2025-12-08 15-47-47" src="https://github.com/user-attachments/assets/f53dde1a-aeee-47d6-8caa-f3b07107fb9b" />

_English US_