### PR TITLE
T2818   A new letter has arrived button should not be shown if the user cannot receive letters 

### DIFF
--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -65,8 +65,10 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         to_date = date(year_to, month_to, last_day)
 
         # Build the domain of the filtering of the letters
-        filter_domain = [("partner_id", "=", partner.id),
-                         ("child_id.can_i_write_letter", "=", True)]
+        filter_domain = [
+            ("partner_id", "=", partner.id),
+            ("child_id.can_i_write_letter", "=", True),
+        ]
 
         if child:
             try:

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -65,7 +65,8 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         to_date = date(year_to, month_to, last_day)
 
         # Build the domain of the filtering of the letters
-        filter_domain = [("partner_id", "=", partner.id)]
+        filter_domain = [("partner_id", "=", partner.id),
+                         ("child_id.can_i_write_letter", "=", True)]
 
         if child:
             try:

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -67,7 +67,11 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         # Build the domain of the filtering of the letters
         filter_domain = [
             ("partner_id", "=", partner.id),
-            ("child_id.can_i_write_letter", "=", True),
+            (
+                "child_id",
+                "in",
+                children_sponsored_by_partner.filtered("can_i_write_letter").ids,
+            ),
         ]
 
         if child:

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -43,13 +43,17 @@ class Partner(models.Model):
         ensure the 'can_i_write_letter' access rights and dependencies are evaluated
         correctly.
         """
-        correspondence = self.env["correspondence"].with_user(self.user_id).search(
-            [
-                ("partner_id", "=", self.id),
-                ("email_read", "=", False),
-                ("child_id.can_i_write_letter", "=", True),
-            ],
-            limit=1,
+        correspondence = (
+            self.env["correspondence"]
+            .with_user(self.user_id)
+            .search(
+                [
+                    ("partner_id", "=", self.id),
+                    ("email_read", "=", False),
+                    ("child_id.can_i_write_letter", "=", True),
+                ],
+                limit=1,
+            )
         )
         return bool(correspondence)
 

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -38,16 +38,11 @@ class Partner(models.Model):
     def has_unread_correspondence(self):
         """
         Check if the partner has at least one unread correspondence.
-
-        This executes in the context of the partner's user (self.user_id) to
-        ensure the 'can_i_write_letter' access rights and dependencies are evaluated
-        correctly.
         """
 
-        children_the_sponsor_can_write_to = self.sponsorship_ids.child_id.filtered(
+        writable_child_ids = self.sponsorship_ids.child_id.filtered(
             "can_i_write_letter"
         ).ids
-        # Can write to
         correspondence = (
             self.env["correspondence"]
             .with_user(self.user_id)
@@ -55,7 +50,7 @@ class Partner(models.Model):
                 [
                     ("partner_id", "=", self.id),
                     ("email_read", "=", False),
-                    ("child_id", "in", children_the_sponsor_can_write_to),
+                    ("child_id", "in", writable_child_ids),
                 ],
                 limit=1,
             )

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -36,11 +36,18 @@ class Partner(models.Model):
                 user.login = partner.user_login
 
     def has_unread_correspondence(self):
-        """Check if partner has at least one correspondence with email_read set."""
-        correspondence = self.env["correspondence"].search(
+        """
+        Check if the partner has at least one unread correspondence.
+
+        This executes in the context of the partner's user (self.user_id) to
+        ensure the 'can_i_write_letter' access rights and dependencies are evaluated
+        correctly.
+        """
+        correspondence = self.env["correspondence"].with_user(self.user_id).search(
             [
                 ("partner_id", "=", self.id),
                 ("email_read", "=", False),
+                ("child_id.can_i_write_letter", "=", True),
             ],
             limit=1,
         )

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -51,6 +51,7 @@ class Partner(models.Model):
                     ("partner_id", "=", self.id),
                     ("email_read", "=", False),
                     ("child_id", "in", writable_child_ids),
+                    ("direction", "=", "Beneficiary To Supporter"),
                 ],
                 limit=1,
             )

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -43,6 +43,11 @@ class Partner(models.Model):
         ensure the 'can_i_write_letter' access rights and dependencies are evaluated
         correctly.
         """
+
+        children_the_sponsor_can_write_to = self.sponsorship_ids.child_id.filtered(
+            "can_i_write_letter"
+        ).ids
+        # Can write to
         correspondence = (
             self.env["correspondence"]
             .with_user(self.user_id)
@@ -50,7 +55,7 @@ class Partner(models.Model):
                 [
                     ("partner_id", "=", self.id),
                     ("email_read", "=", False),
-                    ("child_id.can_i_write_letter", "=", True),
+                    ("child_id", "in", children_the_sponsor_can_write_to),
                 ],
                 limit=1,
             )


### PR DESCRIPTION
## Summary
This PR solves a logic bug that allowed users to be notified when a new letter from a child they don't sponsor or write to has been received.

Note: this PR also solves T2861
### How to reproduce : 
1 ) Select an account in which the user received a letter from a child they're not sponsoring or corresponding. Take the following partner id : **24563** and the following correspondence id : **324445**. In this case, the partner is neither the sponsor nor the correspondent in the contract related to the child. 
2) On the dash board, click on the "A new letter has arrived!" or go to the "Letter" section
3) BOOOM

### Why this happens 
A child can normal write to their sponsor or their correspondent. When it's not the case, the field "partner_id" of the correspondence model points to an unrelated user that does not have the right to access the correspondence record. 

### How to prevent this
To make sure sponsors only load letters they are authorized to (if they are info_all, correspondent or  fully_managers), a check can be done in the domain to filter-out unauthorized letters when fetching letters. 

