### PR TITLE
T2848 some strings are not exported to the po file

### DIFF
--- a/my_compassion/templates/components/my2_donation_form.xml
+++ b/my_compassion/templates/components/my2_donation_form.xml
@@ -56,8 +56,8 @@
             <input type="hidden" name="product_id" t-att-value="product.id" />
             <t t-set="top_class" t-value="None" />
             <t t-call="theme_compassion_2025.TitleComponent">
-                <t t-if="product.my_compassion_donation_type == 'fund'" t-set="title_content" t-value="'Donate'" />
-                <t t-if="product.my_compassion_donation_type == 'gift'" t-set="title_content" t-value="'Give'" />
+                <t t-if="product.my_compassion_donation_type == 'fund'" t-set="title_content">Donate</t>
+                <t t-if="product.my_compassion_donation_type == 'gift'" t-set="title_content">Give</t>
                 <t t-set="color" t-value="'core-blue'" />
                 <t t-set="show_underline" t-value="True" />
                 <t t-set="underline_color" t-value="'low-yellow'" />
@@ -80,7 +80,7 @@
                 <t t-set="top_class" t-value="'mt-3 w-100'" />
                 <t t-set="label">To</t>
                 <t t-set="input_id" t-value="'recipient'" />
-                <t t-set="invalid_hint" t-value="'Please select a recipient.'" />
+                <t t-set="invalid_hint">Please select a recipient.</t>
                 <t t-call="theme_compassion_2025.SelectComponent">
                     <t t-set="name" t-value="'recipient'" />
                     <t t-set="id" t-value="'recipient'" />
@@ -170,7 +170,7 @@
                 <t t-call="theme_compassion_2025.FormFieldComponent">
                     <t t-set="top_class" t-value="'my-3 w-100'" />
                     <t t-set="label">Or enter your own amount</t>
-                    <t t-set="invalid_hint" t-value="'Please enter a valid amount.'" />
+                    <t t-set="invalid_hint">Please enter a valid amount.</t>
                     <div class="donation-suggested-amount">
                         <input
                             t-attf-id="#{base_name}-suggested-custom"

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -475,8 +475,10 @@
                         <t t-set="color" t-value="'core-blue'" />
                         <t t-set="show_underline" t-value="True" />
                         <t t-set="underline_color" t-value="'low-yellow'" />
-                        <t t-set="description">Follow the thread of hope and
-                        encouragement you’ve woven together.</t>
+                        <t t-set="description">
+                            Follow the thread of hope and
+                        encouragement you’ve woven together.
+                        </t>
                     </t>
                 </div>
             </div>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -475,11 +475,8 @@
                         <t t-set="color" t-value="'core-blue'" />
                         <t t-set="show_underline" t-value="True" />
                         <t t-set="underline_color" t-value="'low-yellow'" />
-                        <t
-                            t-set="description"
-                            t-value="'Follow the thread of hope and
-                        encouragement you’ve woven together.'"
-                        />
+                        <t t-set="description">Follow the thread of hope and
+                        encouragement you’ve woven together.</t>
                     </t>
                 </div>
             </div>

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -67,11 +67,8 @@ Page: My Compassion 2 Children Page
                             <t t-set="color" t-value="'core-blue'" />
                             <t t-set="underline_color" t-value="'low-yellow'" />
                             <t t-set="show_underline" t-value="True" />
-                            <t
-                                t-set="description"
-                                t-value="'Because of the Lord’s great love we are not consumed, for his compassions never fail.
-                                They are new every morning; great is your faithfulness. Lamentations 3.22-23'"
-                            />
+                            <t t-set="description">Because of the Lord’s great love we are not consumed, for his compassions never fail.
+                                They are new every morning; great is your faithfulness. Lamentations 3.22-23</t>
                         </t>
                     </div>
                     <div class="container-content d-flex flex-column align-items-center mb-5">

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -67,8 +67,10 @@ Page: My Compassion 2 Children Page
                             <t t-set="color" t-value="'core-blue'" />
                             <t t-set="underline_color" t-value="'low-yellow'" />
                             <t t-set="show_underline" t-value="True" />
-                            <t t-set="description">Because of the Lord’s great love we are not consumed, for his compassions never fail.
-                                They are new every morning; great is your faithfulness. Lamentations 3.22-23</t>
+                            <t t-set="description">
+                                Because of the Lord’s great love we are not consumed, for his compassions never fail.
+                                They are new every morning; great is your faithfulness. Lamentations 3.22-23
+                            </t>
                         </t>
                     </div>
                     <div class="container-content d-flex flex-column align-items-center mb-5">

--- a/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
+++ b/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
@@ -513,8 +513,8 @@ Page: My Compassion 2 New Sponsorship Wizard Page
                 <t t-call="theme_compassion_2025.ThemedButtonComponent">
                     <t t-set="variant" t-value="'compact'" />
                     <t t-set="variation" t-value="'filled'" />
-                    <t t-if="wizard.current_step_idx &lt; (wizard.n_steps-1)" t-set="label" t-value="'Continue'" />
-                    <t t-else="" t-set="label" t-value="'Finish'" />
+                    <t t-if="wizard.current_step_idx &lt; (wizard.n_steps-1)" t-set="label">Continue</t>
+                    <t t-else="" t-set="label">Finish</t>
                     <t t-set="color" t-value="'core-blue'" />
                     <t t-set="text_color" t-value="'pure-white'" />
                     <!-- ID used by eBill extension in my_compassion_switzerland -->


### PR DESCRIPTION
## Summary. 
Like https://github.com/CompassionCH/compassion-website/pull/214 but better. 

This PR is linked to :  https://github.com/CompassionCH/compassion-switzerland/pull/1713

## What have changed: 
- New key-tags are considered: **internal_link_label** and **invalid_hint**
- XML lines containing a \n were not considered, now they are. 

## Script v2 
[script_clean.py](https://github.com/user-attachments/files/24130483/script_clean.py)

