### PR TITLE
T2841 letters should be open in a new tab

### DIFF
--- a/my_compassion/static/src/js/my2_child_letters.js
+++ b/my_compassion/static/src/js/my2_child_letters.js
@@ -13,6 +13,7 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
     document.querySelectorAll(".my2-envelope").forEach((envelope) => {
         envelope.addEventListener("click", function () {
             const letter = envelope.querySelector(".env-letter");
+            const target = envelope.dataset.target || "_self";
 
             if (!envelope.classList.contains("already-read")) {
                 // Iframe
@@ -42,7 +43,7 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
                 setTimeout(function () {
                     const href = envelope.getAttribute("href");
                     if (href) {
-                        window.location.href = href;
+                        window.open(href, target);
                     }
                 }, 1400);
             } else {
@@ -52,7 +53,7 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
                 setTimeout(function () {
                     const href = envelope.getAttribute("href");
                     if (href) {
-                        window.location.href = href;
+                        window.open(href, target);
                     }
                 }, 600);
             }

--- a/my_compassion/static/src/js/my2_child_letters.js
+++ b/my_compassion/static/src/js/my2_child_letters.js
@@ -43,8 +43,7 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
                 setTimeout(function () {
                     const href = envelope.getAttribute("href");
                     if (href) {
-                        window.open(href, target, target === "_blank" ?
-                        "noopener,noreferrer" : null);
+                        window.open(href, target, target === "_blank" ? "noopener,noreferrer" : null);
                     }
                 }, 1400);
             } else {
@@ -54,8 +53,7 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
                 setTimeout(function () {
                     const href = envelope.getAttribute("href");
                     if (href) {
-                        window.open(href, target, target === "_blank" ?
-                        "noopener,noreferrer" : null);
+                        window.open(href, target, target === "_blank" ? "noopener,noreferrer" : null);
                     }
                 }, 600);
             }

--- a/my_compassion/static/src/js/my2_child_letters.js
+++ b/my_compassion/static/src/js/my2_child_letters.js
@@ -43,7 +43,8 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
                 setTimeout(function () {
                     const href = envelope.getAttribute("href");
                     if (href) {
-                        window.open(href, target);
+                        window.open(href, target, target === "_blank" ?
+                        "noopener,noreferrer" : null);
                     }
                 }, 1400);
             } else {
@@ -53,7 +54,8 @@ odoo.define("my_compassion.my2_child_letters", function (require) {
                 setTimeout(function () {
                     const href = envelope.getAttribute("href");
                     if (href) {
-                        window.open(href, target);
+                        window.open(href, target, target === "_blank" ?
+                        "noopener,noreferrer" : null);
                     }
                 }, 600);
             }

--- a/my_compassion/templates/components/my2_letter_card.xml
+++ b/my_compassion/templates/components/my2_letter_card.xml
@@ -23,12 +23,14 @@
                     t-att-data-letter-id="letter.id"
                     t-att-data-letter-read="letter.email_read"
                     t-att-data-letter-uuid="letter.uuid"
+                    data-target="_blank"
                 >
                     <div class="env-body" />
                     <div class="env-letter">
                         <!-- Letter preview -->
                         <!-- TODO Using an iframe for each letter card to show a preview can lead to significant performance issues.
                               For better performance, consider lazy-loading the src of the <iframe>.
+                              You could set the src attribute via JavaScript only when the card is about to become visible in the viewport
                               You could set the src attribute via JavaScript only when the card is about to become visible in the viewport
                               (e.g., using IntersectionObserver) or when the user initiates the envelope-opening animation.
                         -->
@@ -81,6 +83,7 @@
                             <a
                                 class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3"
                                 t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
+                                t-att-target="'_blank'"
                             >
                                 Preview
                                 <i class="icon-eye ml-auto" />

--- a/my_compassion/templates/components/my2_letter_card.xml
+++ b/my_compassion/templates/components/my2_letter_card.xml
@@ -31,7 +31,6 @@
                         <!-- TODO Using an iframe for each letter card to show a preview can lead to significant performance issues.
                               For better performance, consider lazy-loading the src of the <iframe>.
                               You could set the src attribute via JavaScript only when the card is about to become visible in the viewport
-                              You could set the src attribute via JavaScript only when the card is about to become visible in the viewport
                               (e.g., using IntersectionObserver) or when the user initiates the envelope-opening animation.
                         -->
                         <!-- The iframe is already loaded for the letters that have already been read -->
@@ -84,6 +83,7 @@
                                 class="dropdown-item d-flex align-items-center pt-0 pb-0 pl-3 pr-3"
                                 t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf"
                                 t-att-target="'_blank'"
+                                rel="noopener noreferrer"
                             >
                                 Preview
                                 <i class="icon-eye ml-auto" />

--- a/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
+++ b/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
@@ -63,6 +63,7 @@
                     <div class="cd-timeline__img bg-core-blue">
                         <a
                             t-att-href="'/b2s_image?id=' + item['record_id'] + '&amp;disposition=inline&amp;file_type=pdf'"
+                            t-att-target="'_blank'"
                             class="flex items-center justify-center w-full h-full rounded-full"
                         >
                             <i class="pictogram pictogram-letter-writing bg-pure-white" />
@@ -71,6 +72,7 @@
                     <a
                         class="cd-timeline__content text-component text-decoration-none"
                         t-att-href="'/b2s_image?id=' + item['record_id'] + '&amp;disposition=inline&amp;file_type=pdf'"
+                        t-att-target="'_blank'"
                     >
                         <p class="modal-title text-core-blue">
                             <t t-esc="item['title']" />

--- a/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
+++ b/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
@@ -64,6 +64,7 @@
                         <a
                             t-att-href="'/b2s_image?id=' + item['record_id'] + '&amp;disposition=inline&amp;file_type=pdf'"
                             t-att-target="'_blank'"
+                            rel="noopener noreferrer"
                             class="flex items-center justify-center w-full h-full rounded-full"
                         >
                             <i class="pictogram pictogram-letter-writing bg-pure-white" />
@@ -73,6 +74,7 @@
                         class="cd-timeline__content text-component text-decoration-none"
                         t-att-href="'/b2s_image?id=' + item['record_id'] + '&amp;disposition=inline&amp;file_type=pdf'"
                         t-att-target="'_blank'"
+                        rel="noopener noreferrer"
                     >
                         <p class="modal-title text-core-blue">
                             <t t-esc="item['title']" />


### PR DESCRIPTION
# UI: Open Letters in a New Browser Tab

## Problem Description

The expected behavior when opening a letter was not consistent across the application.  
In several places, clicking on a letter would open it in the **current browser tab**, interrupting the user’s navigation flow.

This Pull Request addresses this issue by ensuring that letters are opened in a **new browser tab** when clicked, improving usability and aligning with common UX expectations.

---

## Justification and Context

User feedback and UX best practices indicate that opening detailed or external-like content (such as letters) should not disrupt the current page context.

This change aims to:
- Preserve the user’s current navigation state.
- Provide a consistent interaction pattern wherever letters can be accessed.
- Align technical implementation with the intended UI behavior.

---

## Applied Changes and Fixes

The new behavior is now applied **consistently** in the following contexts:

- **Letters page**:  
  Opening a letter in a new tab when clicking **only on the envelope image**.

- **Global access points**:  
  Wherever a letter can be opened, such as:
  - Timeline
  - Dashboard notifications

- **Preview action**:  
  Via the **“Preview”** button available in the dropdown menu (three vertical dots in the top-right corner of the letter component).

---

## Technical Changes

### XML / QWeb Updates
- Added `t-att-target="'_blank'"` or `data-target="_blank"` to the relevant anchor tags in the templates.
- This explicitly enforces opening the link in a new browser tab.

### JavaScript Updates
- Updated the link opening mechanism:
  - **Before:**  
    ```js
    window.location.href = href;
    ```
  - **After:**  
    ```js
    window.open(href, target);
    ```

- This change is required because `window.open()` is the only method that allows specifying a target context (e.g. `_blank`), whereas `window.location.href` always opens in the current tab.

- The `target` value is retrieved from:
  - `envelope.dataset.target` (set to `_blank` in the related XML), or
  - Defaults to `_self` when not explicitly defined.

---

## Impact

- No breaking changes.
- Improved UX consistency across the application.
- Clear separation between navigation context and content preview.