### PR TITLE
T2834 Improve choose for me new sponsorship workflow

### DIFF
--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -135,7 +135,8 @@ class MyCompassionSponsorshipsController(WebsiteChild):
         child_obj = request.env["compassion.child"]
         total_results = child_obj.search_count(domain)
 
-        child_id = None
+        child = None
+        html_content = ""
         if total_results != 0:
             children = child_obj.search(
                 domain,
@@ -143,10 +144,20 @@ class MyCompassionSponsorshipsController(WebsiteChild):
                 offset=random.randint(0, total_results - 1),
             )
 
-            child_id = children[0].id if children else None
+            if children[0]:
+                child = children[0]
+
+                html_content = request.env["ir.qweb"]._render(
+                    "my_compassion.my2_sponsorships_results_content",
+                    {
+                        "children": children,
+                        "sponsorship_type": post.get("sponsorship_type", "standard"),
+                    },
+                )
 
         return {
-            "child_id": child_id,
+            "child_id": child.id,
+            "html": html_content,
         }
 
     @classmethod

--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -144,7 +144,7 @@ class MyCompassionSponsorshipsController(WebsiteChild):
                 offset=random.randint(0, total_results - 1),
             )
 
-            if children and len(children) > 0:
+            if children:
                 child = children[0]
 
                 html_content = request.env["ir.qweb"]._render(

--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -144,7 +144,7 @@ class MyCompassionSponsorshipsController(WebsiteChild):
                 offset=random.randint(0, total_results - 1),
             )
 
-            if children[0]:
+            if children and len(children) > 0:
                 child = children[0]
 
                 html_content = request.env["ir.qweb"]._render(
@@ -156,7 +156,7 @@ class MyCompassionSponsorshipsController(WebsiteChild):
                 )
 
         return {
-            "child_id": child.id,
+            "child_id": child.id if child else None,
             "html": html_content,
         }
 

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -9,6 +9,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
         var publicWidget = require("web.public.widget");
         var rpc = require("web.rpc");
+        var core = require("web.core");
+        var _t = core._t;
 
         publicWidget.registry.Sponsorships = publicWidget.Widget.extend({
             selector: ".sponsorships-body-container",
@@ -18,6 +20,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 'change input[type="radio"][name="gender"]': "_onGenderChange",
                 "click #btn-more": "_onShowMore",
                 "click #btn-choose": "_onChooseRandom",
+                "click #btn-choose-again": "_onChooseRandom",
             },
 
             custom_events: {
@@ -42,6 +45,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 this.resultsPerBatch = 20;
                 this.resultsLoaded = 0;
                 this.totalResults = 0;
+                // Id of the randomly sampled child, mostly used to see if sampling happened and condition the UI (Button visibility)
+                // If null, no child sampled. This is reset on each filter change.
+                this.randomlySampledChildId = null;
 
                 this.sponsorship_type = this.$el.data("sponsorship-type");
 
@@ -60,6 +66,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
              */
             _refreshResults: function () {
                 this.$(".sponsorships-results-content").empty();
+                this.randomlySampledChildId = null;
                 this.resultsLoaded = 0;
                 this.totalResults = 0;
                 this._updateTotalResultsLabel();
@@ -179,10 +186,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
              * @private
              */
             _updateChooseForMeButton: function () {
-                if (this.totalResults == 0) {
+                if (this.totalResults == 0 || this.randomlySampledChildId) {
                     this.$("#btn-choose").hide();
+                    if (this.randomlySampledChildId) {
+                        this.$("#btn-choose-again").show().prop("disabled", false);
+                        this.$("#btn-see-all-children").show().prop("disabled", false);
+                    }
                 } else {
                     this.$("#btn-choose").show().prop("disabled", false);
+                    this.$("#btn-choose-again").hide();
+                    this.$("#btn-see-all-children").hide();
                 }
             },
 
@@ -259,8 +272,11 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     .then(
                         function (data) {
                             if (data.child_id) {
+                                this.randomlySampledChildId = data.child_id;
+                                this._updateChooseForMeButton();
                                 // Delete all the current results
                                 this.$(".sponsorships-results-content").empty();
+
                                 this._appendAndAnimate(data.html, this.$(".sponsorships-results-content"));
                             }
                             this.$(".btn").prop("disabled", false);

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -96,6 +96,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         $(self).addClass("show");
                     }, 100 + index * 50);
                 });
+            },
+
+            /**
              * Handles RPC errors by displaying the my_compassion2 error toast.
              *
              * @private

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -198,8 +198,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 if (this.randomlySampledChildId) {
                     // A child has been randomly chosen
                     this.$("#btn-choose").hide();
-                    this.$("#btn-choose-again").show().prop("disabled", false);
-                    this.$("#btn-see-all-children").show().prop("disabled", false);
+                    this.$("#btn-choose-again").show();
+                    this.$("#btn-see-all-children").show();
                 } else {
                     // Normal view (all children or no results)
                     this.$("#btn-choose-again").hide();

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -179,7 +179,15 @@ document.addEventListener("DOMContentLoaded", function (event) {
              * @private
              */
             _updateTotalResultsLabel: function () {
-                this.$("#total-results").text(this.totalResults);
+                if (this.randomlySampledChildId) {
+                    this.$("#total-children-found-message").hide();
+                    this.$("#randomly-chosen-child-message").show();
+                } else {
+                    this.$("#total-children-found-message").show();
+                    this.$("#randomly-chosen-child-message").hide();
+
+                    this.$("#total-results").text(this.totalResults);
+                }
             },
 
             /**
@@ -189,9 +197,13 @@ document.addEventListener("DOMContentLoaded", function (event) {
             _updateChooseForMeButton: function () {
                 if (this.totalResults == 0 || this.randomlySampledChildId) {
                     this.$("#btn-choose").hide();
+                    // If a child has been randomly sampled, update the UI
                     if (this.randomlySampledChildId) {
+                        //Show the "Choose again" and "See all children" buttons
                         this.$("#btn-choose-again").show().prop("disabled", false);
                         this.$("#btn-see-all-children").show().prop("disabled", false);
+                        //Hide the number of results label
+                        this.$("#total-results-container").hide();
                     }
                 } else {
                     this.$("#btn-choose").show().prop("disabled", false);
@@ -275,6 +287,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             if (data.child_id) {
                                 this.randomlySampledChildId = data.child_id;
                                 this._updateChooseForMeButton();
+                                this._updateTotalResultsLabel();
                                 // Delete all the current results
                                 this.$(".sponsorships-results-content").empty();
 

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -68,6 +68,28 @@ document.addEventListener("DOMContentLoaded", function (event) {
             },
 
             /**
+             * Appends HTML to a container and applies a staggered animation.
+             * * @param {string} htmlContent - The raw HTML string (e.g., data.html)
+             * @param {jQuery} $container  - The jQuery object to append to (e.g., $resultsContainer)
+             */
+            _appendAndAnimate: function (htmlContent, $container) {
+                // 1. Create jQuery objects from the HTML and add the initial class
+                const $newItems = $(htmlContent).addClass("animate-in");
+
+                // 2. Append the new results to the container
+                $container.append($newItems);
+
+                // 3. Loop over each new item to apply the staggered delay
+                $newItems.each(function (index) {
+                    var self = this;
+                    // Apply 100ms base delay + 50ms per item
+                    setTimeout(function () {
+                        $(self).addClass("show");
+                    }, 100 + index * 50);
+                });
+            },
+
+            /**
              * Fetches and displays the next batch of sponsorships from the backend.
              * @private
              */
@@ -107,19 +129,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
                             if (data.count && data.html) {
                                 // Parse the HTML string into jQuery objects and add the initial animation class.
-                                const $newItems = $(data.html).addClass("animate-in");
-
-                                // Append the new results
-                                $resultsContainer.append($newItems);
-
-                                // Loop over each new item to apply a staggered delay
-                                $newItems.each(function (index) {
-                                    // Apply 50ms offset + slight delay to give the browser a moment to apply the initial styles
-                                    var self = this;
-                                    setTimeout(function () {
-                                        $(self).addClass("show");
-                                    }, 100 + index * 50);
-                                });
+                                this._appendAndAnimate(data.html, $resultsContainer);
 
                                 // Update the count of loaded results
                                 this.resultsLoaded += data.count;
@@ -249,9 +259,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     .then(
                         function (data) {
                             if (data.child_id) {
-                                // Redirect to new sponsorship page
-                                window.location.href =
-                                    "/my2/new-sponsorship/" + data.child_id + "?type=" + this.sponsorship_type;
+                                // Delete all the current results
+                                this.$(".sponsorships-results-content").empty();
+                                this._appendAndAnimate(data.html, this.$(".sponsorships-results-content"));
                             }
                             this.$(".btn").prop("disabled", false);
                         }.bind(this)

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -21,6 +21,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 "click #btn-more": "_onShowMore",
                 "click #btn-choose": "_onChooseRandom",
                 "click #btn-choose-again": "_onChooseRandom",
+                "click #btn-see-all-children": "_refreshResults",
             },
 
             custom_events: {

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -10,7 +10,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
         var publicWidget = require("web.public.widget");
         var rpc = require("web.rpc");
         var core = require("web.core");
-        var _t = core._t;
 
         publicWidget.registry.Sponsorships = publicWidget.Widget.extend({
             selector: ".sponsorships-body-container",
@@ -180,12 +179,13 @@ document.addEventListener("DOMContentLoaded", function (event) {
              */
             _updateTotalResultsLabel: function () {
                 if (this.randomlySampledChildId) {
+                    // If a child has been randomly sampled, show the appropriate message
                     this.$("#total-children-found-message").hide();
                     this.$("#randomly-chosen-child-message").show();
                 } else {
                     this.$("#total-children-found-message").show();
                     this.$("#randomly-chosen-child-message").hide();
-
+                    // Update the total results count
                     this.$("#total-results").text(this.totalResults);
                 }
             },

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -9,7 +9,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
         var publicWidget = require("web.public.widget");
         var rpc = require("web.rpc");
-        var core = require("web.core");
 
         publicWidget.registry.Sponsorships = publicWidget.Widget.extend({
             selector: ".sponsorships-body-container",

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -195,20 +195,20 @@ document.addEventListener("DOMContentLoaded", function (event) {
              * @private
              */
             _updateChooseForMeButton: function () {
-                if (this.totalResults == 0 || this.randomlySampledChildId) {
+                if (this.randomlySampledChildId) {
+                    // A child has been randomly chosen
                     this.$("#btn-choose").hide();
-                    // If a child has been randomly sampled, update the UI
-                    if (this.randomlySampledChildId) {
-                        //Show the "Choose again" and "See all children" buttons
-                        this.$("#btn-choose-again").show().prop("disabled", false);
-                        this.$("#btn-see-all-children").show().prop("disabled", false);
-                        //Hide the number of results label
-                        this.$("#total-results-container").hide();
-                    }
+                    this.$("#btn-choose-again").show().prop("disabled", false);
+                    this.$("#btn-see-all-children").show().prop("disabled", false);
                 } else {
-                    this.$("#btn-choose").show().prop("disabled", false);
+                    // Normal view (all children or no results)
                     this.$("#btn-choose-again").hide();
                     this.$("#btn-see-all-children").hide();
+                    if (this.totalResults > 0) {
+                        this.$("#btn-choose").show().prop("disabled", false);
+                    } else {
+                        this.$("#btn-choose").hide();
+                    }
                 }
             },
 

--- a/my_compassion/static/src/js/my2_sponsorships.js
+++ b/my_compassion/static/src/js/my2_sponsorships.js
@@ -78,7 +78,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
             /**
              * Appends HTML to a container and applies a staggered animation.
-             * * @param {string} htmlContent - The raw HTML string (e.g., data.html)
+             * @param {string} htmlContent - The raw HTML string (e.g., data.html)
              * @param {jQuery} $container  - The jQuery object to append to (e.g., $resultsContainer)
              */
             _appendAndAnimate: function (htmlContent, $container) {

--- a/my_compassion/templates/pages/my2_sponsorships.xml
+++ b/my_compassion/templates/pages/my2_sponsorships.xml
@@ -48,21 +48,30 @@ Page: My Compassion 2 Sponsorships Page
                     <i id="sponsorships-title-icon" class="pictogram-child-sponsorship text-low-yellow mt-4" />
                     <h2 class="text-pure-white text-center">
                         <t t-if="sponsorship_type == 'write_and_pray'">
-                            You write to and pray for a child, someone else sponsors the relationship
+                            You write to and pray for a child, someone else sponsors the
+                            relationship
                         </t>
                         <t t-else="">Sponsor a child</t>
                     </h2>
                     <div class="body-large bold text-pure-white text-center mt-3 mb-2">
                         <t t-if="sponsorship_type == 'write_and_pray'">
-                            Lifting a child out of poverty can also be a team effort! A donor pays. A sponsor writes to the
-                            child and prays for them. Thanks to the “Write &amp; Pray” sponsorship program set up for young
-                            people under the age of 25, these two acts of generosity can work together.
+                            Lifting a child out of poverty can also be a team effort! A
+                            donor pays. A sponsor writes to the
+                            child and prays for them. Thanks to the “Write &amp; Pray”
+                            sponsorship program set up for young
+                            people under the age of 25, these two acts of generosity can
+                            work together.
                             <br /> <br />
-                            You can choose below (or ask us to choose for you) a child you would like to sponsor. Your
-                            commitment? Pray for them regularly and write to them at least twice a year, sending letters of
+                            You can choose below (or ask us to choose for you) a child
+                            you would like to sponsor. Your
+                            commitment? Pray for them regularly and write to them at
+                            least twice a year, sending letters of
                             support and encouragement.
                         </t>
-                        <t t-else="">Stand with the Church and See a Child Released from Poverty</t>
+                        <t t-else="">
+                            Stand with the Church and See a Child Released from
+                            Poverty
+                        </t>
                     </div>
                 </div>
             </div>
@@ -128,6 +137,24 @@ Page: My Compassion 2 Sponsorships Page
                             <t t-set="variant" t-value="'compact'" />
                             <t t-set="variation" t-value="'hollow'" />
                             <t t-set="label">Choose for me</t>
+                            <t t-set="color" t-value="'dark-blue'" />
+                            <t t-set="text_color" t-value="'dark-blue'" />
+                        </t>
+                    </div>
+                    <div id="btn-choose-again" class="mr-3" style="display: none;">
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variant" t-value="'compact'" />
+                            <t t-set="variation" t-value="'hollow'" />
+                            <t t-set="label">Choose another child</t>
+                            <t t-set="color" t-value="'dark-blue'" />
+                            <t t-set="text_color" t-value="'dark-blue'" />
+                        </t>
+                    </div>
+                    <div id="btn-see-all-children" class="mr-3" style="display: none;">
+                        <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                            <t t-set="variant" t-value="'compact'" />
+                            <t t-set="variation" t-value="'hollow'" />
+                            <t t-set="label">See them all</t>
                             <t t-set="color" t-value="'dark-blue'" />
                             <t t-set="text_color" t-value="'dark-blue'" />
                         </t>

--- a/my_compassion/templates/pages/my2_sponsorships.xml
+++ b/my_compassion/templates/pages/my2_sponsorships.xml
@@ -124,8 +124,13 @@ Page: My Compassion 2 Sponsorships Page
                     <!-- TOTAL RESULTS -->
                     <div class="body-large bold text-mid-grey mt-4 mb-2 align-self-center">
                         <i class="results-icon icon-users03 text-mid-grey mr-2" />
-                        <span id="total-results">0</span>
-                        children found
+                        <span id="total-children-found-message">
+                            <span id="total-results">0</span>
+                            children found
+                        </span>
+                        <span id="randomly-chosen-child-message" style="display: none;">
+                            A child has been chosen for you
+                        </span>
                     </div>
                     <!-- CHILDREN PROFILES -->
                     <div class="sponsorships-results-content row justify-content-center" />

--- a/my_compassion/templates/pages/my2_sponsorships.xml
+++ b/my_compassion/templates/pages/my2_sponsorships.xml
@@ -159,7 +159,7 @@ Page: My Compassion 2 Sponsorships Page
                         <t t-call="theme_compassion_2025.ThemedButtonComponent">
                             <t t-set="variant" t-value="'compact'" />
                             <t t-set="variation" t-value="'hollow'" />
-                            <t t-set="label">See them all</t>
+                            <t t-set="label">See all</t>
                             <t t-set="color" t-value="'dark-blue'" />
                             <t t-set="text_color" t-value="'dark-blue'" />
                         </t>


### PR DESCRIPTION
## Summary
This PR introduces a new workflow to the sponsor when trying to sponsor a new child. 
### User story
As a user, I want to see profile card of the randomly sampled child before checking out.

### New design descirption: 
The "Choose for me button" does no longer redirect to the checkout. It shows the card of the randomly sampled child and allow the user to either randomly draw a new one or to see all possible child. 

## Video record of the new design :




[Screencast from 16.12.2025 13:17:05.webm](https://github.com/user-attachments/assets/452f9e14-a9db-4c3c-a694-9a8faefd42b5)


 


