### PR TITLE
[T2851] - Add BannerComponent when user is volunteer on volunteer's page

### DIFF
--- a/theme_compassion_2025/templates/components/Banner.xml
+++ b/theme_compassion_2025/templates/components/Banner.xml
@@ -26,51 +26,28 @@
         <div t-attf-class="d-flex bg-#{color or 'low-blue'} p-2 rounded">
             <div class="p-3">
                 <t t-if="pictogram">
-                    <i t-attf-class="pictogram-#{pictogram} text-#{text_color or 'pure-white'} h1"/>
+                    <i t-attf-class="pictogram-#{pictogram} text-#{text_color or 'pure-white'} h1" />
                 </t>
             </div>
             <div class="d-flex flex-column align-items-start pb-4 pr-4 flex-grow-1">
                 <t t-call="theme_compassion_2025.TitleComponent">
-                    <t t-set="title_content" t-value="title"/>
-                    <t t-set="color" t-value="text_color or 'pure-white'"/>
-                    <t t-set="align_sm" t-value="'left'"/>
+                    <t t-set="title_content" t-value="title" />
+                    <t t-set="color" t-value="text_color or 'pure-white'" />
+                    <t t-set="align_sm" t-value="'left'" />
                 </t>
                 <p class="text-pure-white">
-                    <t t-esc="text"/>
+                    <t t-esc="text" />
                 </p>
                 <div class="align-self-center">
                     <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                        <t t-set="href" t-value="btn_link"/>
-                        <t t-set="label" t-value="btn_text"/>
-                        <t t-set="text_color" t-value="btn_text_color or 'pure-white'"/>
-                        <t t-set="color" t-value="btn_color or 'low-blue'"/>
-                        <t t-set="variation" t-value="btn_variation or 'outlined'"/>
-                        <t t-set="variant" t-value="btn_variant or 'compact'"/>
-
-                        <!--
-                         Security and Flexibility Logic for REL attribute:
-                         1. Passes the 'target' value (if provided) to the button.
-                         2. If target='_blank', security measures are applied to prevent
-                            "Tabnabbing":
-                               a. If the user provided a 'rel' value, it checks if
-                                  'noopener noreferrer' is missing. If missing, the secure
-                                  value is concatenated to the user's existing rel.
-                               b. If the user did not provide a 'rel' value, 'noopener
-                                  noreferrer' is applied as the secure default 'rel' value.
-                         3. If target is NOT '_blank', the user's 'rel' attribute is simply
-                            passed through (if provided).
-                        -->
-                        <t t-if="target" t-set="target" t-value="target"/>
-                        <t t-if="target == '_blank'">
-                            <t t-set="secure_rel" t-value="'noopener noreferrer'"/>
-                            <t t-if="rel">
-                                <t t-if="rel.find('noopener noreferrer') == -1">
-                                    <t t-set="rel" t-value="rel + ' ' + secure_rel"/>
-                                </t>
-                            </t>
-                            <t t-else="" t-set="rel" t-value="secure_rel"/>
-                        </t>
-                        <t t-elif="rel" t-set="rel" t-value="rel"/>
+                        <t t-set="href" t-value="btn_link" />
+                        <t t-set="label" t-value="btn_text" />
+                        <t t-set="text_color" t-value="btn_text_color or 'pure-white'" />
+                        <t t-set="color" t-value="btn_color or 'low-blue'" />
+                        <t t-set="variation" t-value="btn_variation or 'outlined'" />
+                        <t t-set="variant" t-value="btn_variant or 'compact'" />
+                        <t t-if="target" t-set="target" t-value="target" />
+                        <t t-if="rel" t-set="rel" t-value="rel" />
                     </t>
                 </div>
             </div>

--- a/theme_compassion_2025/templates/components/Banner.xml
+++ b/theme_compassion_2025/templates/components/Banner.xml
@@ -17,30 +17,62 @@
     - btn_variation (string, optional): Variation of the button, default is 'outlined'.
     - btn_variant (string, optional): Variant of the button, default is 'compact'.
     - btn_link (string): Link for the button.
+    - target (string, optional): Target attribute for the button link (e.g., '_blank').
+    - rel (string, optional): Rel attribute for the button link. Automatically set to
+      'noopener noreferrer' if target='_blank' and no rel is provided.
 -->
 <odoo>
     <template id="BannerComponent" name="Banner Component">
         <div t-attf-class="d-flex bg-#{color or 'low-blue'} p-2 rounded">
             <div class="p-3">
-                <i t-attf-class="pictogram-#{pictogram} text-#{text_color or 'pure-white'} h1" />
+                <t t-if="pictogram">
+                    <i t-attf-class="pictogram-#{pictogram} text-#{text_color or 'pure-white'} h1"/>
+                </t>
             </div>
-            <div class="d-flex flex-column align-items-start pb-4 pr-4">
+            <div class="d-flex flex-column align-items-start pb-4 pr-4 flex-grow-1">
                 <t t-call="theme_compassion_2025.TitleComponent">
-                    <t t-set="title_content" t-value="title" />
-                    <t t-set="color" t-value="text_color or 'pure-white'" />
-                    <t t-set="align_sm" t-value="'left'" />
+                    <t t-set="title_content" t-value="title"/>
+                    <t t-set="color" t-value="text_color or 'pure-white'"/>
+                    <t t-set="align_sm" t-value="'left'"/>
                 </t>
                 <p class="text-pure-white">
-                    <t t-esc="text" />
+                    <t t-esc="text"/>
                 </p>
-                <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                    <t t-set="href" t-value="btn_link" />
-                    <t t-set="label" t-value="btn_text" />
-                    <t t-set="text_color" t-value="btn_text_color or 'pure-white'" />
-                    <t t-set="color" t-value="btn_color or 'low-blue'" />
-                    <t t-set="variation" t-value="btn_variation or 'outlined'" />
-                    <t t-set="variant" t-value="btn_variant or 'compact'" />
-                </t>
+                <div class="align-self-center">
+                    <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                        <t t-set="href" t-value="btn_link"/>
+                        <t t-set="label" t-value="btn_text"/>
+                        <t t-set="text_color" t-value="btn_text_color or 'pure-white'"/>
+                        <t t-set="color" t-value="btn_color or 'low-blue'"/>
+                        <t t-set="variation" t-value="btn_variation or 'outlined'"/>
+                        <t t-set="variant" t-value="btn_variant or 'compact'"/>
+
+                        <!--
+                         Security and Flexibility Logic for REL attribute:
+                         1. Passes the 'target' value (if provided) to the button.
+                         2. If target='_blank', security measures are applied to prevent
+                            "Tabnabbing":
+                               a. If the user provided a 'rel' value, it checks if
+                                  'noopener noreferrer' is missing. If missing, the secure
+                                  value is concatenated to the user's existing rel.
+                               b. If the user did not provide a 'rel' value, 'noopener
+                                  noreferrer' is applied as the secure default 'rel' value.
+                         3. If target is NOT '_blank', the user's 'rel' attribute is simply
+                            passed through (if provided).
+                        -->
+                        <t t-if="target" t-set="target" t-value="target"/>
+                        <t t-if="target == '_blank'">
+                            <t t-set="secure_rel" t-value="'noopener noreferrer'"/>
+                            <t t-if="rel">
+                                <t t-if="rel.find('noopener noreferrer') == -1">
+                                    <t t-set="rel" t-value="rel + ' ' + secure_rel"/>
+                                </t>
+                            </t>
+                            <t t-else="" t-set="rel" t-value="secure_rel"/>
+                        </t>
+                        <t t-elif="rel" t-set="rel" t-value="rel"/>
+                    </t>
+                </div>
             </div>
         </div>
     </template>

--- a/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
+++ b/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
@@ -73,24 +73,23 @@
         </t>
         <!-- Render button or link -->
         <t t-if="href">
-            <t t-set="computed_rel" t-value="rel" />
+            <t t-set="rel_parts" t-value="(rel or '').split()" />
             <t t-if="target == '_blank'">
-                <t t-set="temp_rel" t-value="rel or ''" />
-                <t t-if="'noopener' not in temp_rel">
-                    <t t-set="temp_rel" t-value="temp_rel + ' noopener'" />
+                <t t-if="'noopener' not in rel_parts">
+                    <t t-set="rel_parts" t-value="rel_parts + ['noopener']" />
                 </t>
-                <t t-if="'noreferrer' not in temp_rel">
-                    <t t-set="temp_rel" t-value="temp_rel + ' noreferrer'" />
+                <t t-if="'noreferrer' not in rel_parts">
+                    <t t-set="rel_parts" t-value="rel_parts + ['noreferrer']" />
                 </t>
-                <t t-set="computed_rel" t-value="temp_rel.strip()" />
             </t>
+            <t t-set="computed_rel" t-value="' '.join(rel_parts)" />
             <a
                 t-att-href="href"
                 t-att-id="id"
                 t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
                 t-att-data-custom="data_custom"
                 t-att-target="target"
-                t-att-rel="computed_rel"
+                t-att-rel="computed_rel or None"
             >
                 <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
             </a>

--- a/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
+++ b/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
@@ -75,11 +75,10 @@
         <t t-if="href">
             <t t-set="rel_parts" t-value="(rel or '').split()" />
             <t t-if="target == '_blank'">
-                <t t-if="'noopener' not in rel_parts">
-                    <t t-set="rel_parts" t-value="rel_parts + ['noopener']" />
-                </t>
-                <t t-if="'noreferrer' not in rel_parts">
-                    <t t-set="rel_parts" t-value="rel_parts + ['noreferrer']" />
+                <t t-foreach="['noopener', 'noreferrer']" t-as="security_rel">
+                    <t t-if="security_rel not in rel_parts">
+                        <t t-set="rel_parts" t-value="rel_parts + [security_rel]" />
+                    </t>
                 </t>
             </t>
             <t t-set="computed_rel" t-value="' '.join(rel_parts)" />

--- a/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
+++ b/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
@@ -27,65 +27,72 @@
     - href (string, optional): The URL to link to. If provided, an 'a' tag will be rendered instead of a 'button'.
     - radius (string, optional): Radius of the rounded corners: 'pill' (default) or 'small'
     - data_custom (char, optional): data-custom attribute to be added to the button or link element, e.g., `data-custom="value"`
+    - target (string, optional): The target attribute for the link
+      (e.g., '_blank' to open in a new tab).
+    - rel (string, optional): The rel attribute for the link (e.g., 'noopener noreferrer'
+      for security).
 -->
 <odoo>
     <template id="ThemedButtonComponent_Content" name="Button Content">
         <t t-if="icon">
             <span t-attf-class="btn__icon #{'btn__icon--' + variant if label else ''} text-#{icon_color}">
-                <i t-att-class="icon" />
+                <i t-att-class="icon"/>
             </span>
         </t>
         <t t-if="label">
             <span t-att-id="label_id">
-                <t t-esc="label" />
+                <t t-esc="label"/>
             </span>
         </t>
     </template>
     <template id="ThemedButtonComponent" name="Button Component">
         <!-- Default property values -->
-        <t t-set="radius" t-value="radius or 'pill'" />
+        <t t-set="radius" t-value="radius or 'pill'"/>
         <!-- Determine button style class border or background depending on the variation -->
         <t t-if="variation == 'hollow'">
-            <t t-set="style_class" t-value="'border border-2 border-' + color" />
+            <t t-set="style_class" t-value="'border border-2 border-' + color"/>
         </t>
         <t t-elif="variation == 'filled'">
-            <t t-set="style_class" t-value="'bg-' + color" />
+            <t t-set="style_class" t-value="'bg-' + color"/>
         </t>
         <t t-elif="variation == 'outlined'">
             <t
-                t-set="style_class"
-                t-value="'bg-' + color + ' border border-2 border-' + text_color + ' text-' + color + '-hover'"
+                    t-set="style_class"
+                    t-value="'bg-' + color + ' border border-2 border-' + text_color + ' text-' + color + '-hover'"
             />
         </t>
         <t t-else="">
-            <t t-set="style_class" t-value="'bg-black'" />
+            <t t-set="style_class" t-value="'bg-black'"/>
         </t>
         <!-- Decide main button class depending on icon/label -->
         <t t-if="icon and not label">
-            <t t-set="btn_class" t-value="'btn--' + variant + '-' + variation + '-icon-only'" />
+            <t t-set="btn_class"
+               t-value="'btn--' + variant + '-' + variation + '-icon-only'"/>
         </t>
         <t t-else="">
-            <t t-set="btn_class" t-value="'btn--' + variant + '-' + variation" />
+            <t t-set="btn_class" t-value="'btn--' + variant + '-' + variation"/>
         </t>
         <!-- Render button or link -->
         <t t-if="href">
             <a
-                t-att-href="href"
-                t-att-id="id"
-                t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
-                t-att-data-custom="data_custom"
+                    t-att-href="href"
+                    t-att-id="id"
+                    t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
+                    t-att-data-custom="data_custom"
+                    t-att-target="target"
+                    t-att-rel="rel"
             >
-                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
+                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content"/>
             </a>
         </t>
         <t t-else="">
             <button
-                t-att-id="id"
-                t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
-                t-att-data-custom="data_custom"
-                t-att-data-mode="mode"
+                    t-att-id="id"
+                    t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
+                    t-att-data-custom="data_custom"
+                    t-att-data-mode="mode"
             >
-                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
+                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content"/>
             </button>
         </t>
     </template>

--- a/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
+++ b/theme_compassion_2025/templates/components/buttons/ThemedButton.xml
@@ -36,63 +36,73 @@
     <template id="ThemedButtonComponent_Content" name="Button Content">
         <t t-if="icon">
             <span t-attf-class="btn__icon #{'btn__icon--' + variant if label else ''} text-#{icon_color}">
-                <i t-att-class="icon"/>
+                <i t-att-class="icon" />
             </span>
         </t>
         <t t-if="label">
             <span t-att-id="label_id">
-                <t t-esc="label"/>
+                <t t-esc="label" />
             </span>
         </t>
     </template>
     <template id="ThemedButtonComponent" name="Button Component">
         <!-- Default property values -->
-        <t t-set="radius" t-value="radius or 'pill'"/>
+        <t t-set="radius" t-value="radius or 'pill'" />
         <!-- Determine button style class border or background depending on the variation -->
         <t t-if="variation == 'hollow'">
-            <t t-set="style_class" t-value="'border border-2 border-' + color"/>
+            <t t-set="style_class" t-value="'border border-2 border-' + color" />
         </t>
         <t t-elif="variation == 'filled'">
-            <t t-set="style_class" t-value="'bg-' + color"/>
+            <t t-set="style_class" t-value="'bg-' + color" />
         </t>
         <t t-elif="variation == 'outlined'">
             <t
-                    t-set="style_class"
-                    t-value="'bg-' + color + ' border border-2 border-' + text_color + ' text-' + color + '-hover'"
+                t-set="style_class"
+                t-value="'bg-' + color + ' border border-2 border-' + text_color + ' text-' + color + '-hover'"
             />
         </t>
         <t t-else="">
-            <t t-set="style_class" t-value="'bg-black'"/>
+            <t t-set="style_class" t-value="'bg-black'" />
         </t>
         <!-- Decide main button class depending on icon/label -->
         <t t-if="icon and not label">
-            <t t-set="btn_class"
-               t-value="'btn--' + variant + '-' + variation + '-icon-only'"/>
+            <t t-set="btn_class" t-value="'btn--' + variant + '-' + variation + '-icon-only'" />
         </t>
         <t t-else="">
-            <t t-set="btn_class" t-value="'btn--' + variant + '-' + variation"/>
+            <t t-set="btn_class" t-value="'btn--' + variant + '-' + variation" />
         </t>
         <!-- Render button or link -->
         <t t-if="href">
+            <t t-set="computed_rel" t-value="rel" />
+            <t t-if="target == '_blank'">
+                <t t-set="temp_rel" t-value="rel or ''" />
+                <t t-if="'noopener' not in temp_rel">
+                    <t t-set="temp_rel" t-value="temp_rel + ' noopener'" />
+                </t>
+                <t t-if="'noreferrer' not in temp_rel">
+                    <t t-set="temp_rel" t-value="temp_rel + ' noreferrer'" />
+                </t>
+                <t t-set="computed_rel" t-value="temp_rel.strip()" />
+            </t>
             <a
-                    t-att-href="href"
-                    t-att-id="id"
-                    t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
-                    t-att-data-custom="data_custom"
-                    t-att-target="target"
-                    t-att-rel="rel"
+                t-att-href="href"
+                t-att-id="id"
+                t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
+                t-att-data-custom="data_custom"
+                t-att-target="target"
+                t-att-rel="computed_rel"
             >
-                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content"/>
+                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
             </a>
         </t>
         <t t-else="">
             <button
-                    t-att-id="id"
-                    t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
-                    t-att-data-custom="data_custom"
-                    t-att-data-mode="mode"
+                t-att-id="id"
+                t-attf-class="btn #{btn_class} btn--radius-#{radius} #{style_class} text-#{text_color}"
+                t-att-data-custom="data_custom"
+                t-att-data-mode="mode"
             >
-                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content"/>
+                <t t-call="theme_compassion_2025.ThemedButtonComponent_Content" />
             </button>
         </t>
     </template>


### PR DESCRIPTION
# UI: Banner and Button Enhancements with Security and Layout Improvements

## Problem Description

Several technical, security, and layout issues were identified around the **BannerComponent** and **ThemedButtonComponent**, as well as inconsistencies in how banners were displayed across different pages.

These issues impacted:

- Security best practices for external links (Tabnabbing protection).  
- Layout consistency and visual alignment, especially on the **Gifts** page.  
- Controlled visibility of banners on the **Volunteering** page.

---

## Justification and Context

The goal of this PR is to introduce **robust and maintainable improvements** that enhance:

- Security when opening external links by centralizing logic in the base component.  
- Flexibility of reusable UI components.  
- Visual consistency and alignment across pages, regardless of content length.

While the functional impact is targeted, these changes improve the overall quality, UX consistency, and security of shared UI components.

---

## Applied Changes and Fixes

### 1. Volunteering Page – Conditional Banner Display

- Integration of the **BannerComponent** on the Volunteering page.  
- The banner is displayed **only for users with a volunteer status**, ensuring contextual relevance and avoiding unnecessary exposure for other users.

---

### 2. Link Security and Flexibility (target & rel)

Support for `target` and `rel` props has been added to both **BannerComponent** and **ThemedButtonComponent**.

#### Automated and Robust Security Handling

To prevent **tabnabbing attacks** when using `target="_blank"`, the security logic has been centralized in the **ThemedButtonComponent**:

- **Token-based Validation**  
  Instead of a simple substring search, the logic now splits the `rel` attribute into a list of tokens. This ensures that security attributes (`noopener`, `noreferrer`) are detected accurately, avoiding false positives from custom class names or other attributes.

- **DRY Implementation**  
  Using a `t-foreach` loop, the component checks and injects required security values only if they are missing. This makes the code cleaner and easier to extend.

- **Smart Concatenation**  
  Custom `rel` values (like `nofollow`) are preserved and merged seamlessly with security requirements, preventing redundant manual assignments in calling templates.

---

### 3. UI & Layout Optimizations (Flexbox)

Several layout adjustments were made to ensure consistent alignment and spacing across all pages using the Banner component.

- **Button alignment (`align-self-center`)**  
  The button is now horizontally centered using `align-self-center`. This allows overriding the parent container’s `align-items-start` behavior without impacting the alignment of the title or text.

- **Content width management (`flex-grow-1`)**  

  The **BannerComponent** is also used on the **Gifts** page, but on this page the content area (text + button) did not occupy the full available horizontal space next to the pictogram.

  **Observed Issue:**  
  - The content area appeared compressed to the left.  
  - The button seemed centered only relative to the text above it, not the entire banner, creating a visual imbalance.  
  - This layout issue occurred **only on the Gifts page**, while the component works correctly on the **Volunteering page**.

  **Visual Impact:**  
  Without full width, the button's centering was visually off-balance because it was relative to the short text rather than the banner itself.

  **Solution:**  
  Adding `flex-grow-1` forces the content container to expand and fill the remaining horizontal space, ensuring:  
  - Proper centering of the button relative to the entire banner.  
  - A consistent and balanced layout on all pages using the BannerComponent.

---

## Related PRs

This set of improvements is complemented by a related PR in the **Compassion-switzerland** repository:

- PR: [[T2851] - Add BannerComponent when user is volunteer on volunteer's page #1715](https://github.com/CompassionCH/compassion-switzerland/pull/1715)
