### PR TITLE
T2842 move new sponsorship button and subtitle

### DIFF
--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -47,7 +47,9 @@ Page: My Compassion 2 Children Page
                 </div>
                 <!-- TEXT DESCRIPTION -->
                 <div class="single-column">
-                    <p class="title-description text-low-black text-center mb-3">Hearts grow stronger with each act of love through your sponsorship.</p>
+                    <p class="title-description text-low-black text-center mb-3">
+                        Hearts grow stronger with each act of love through your sponsorship.
+                    </p>
                     <!-- NEW SPONSORSHIP BUTTON -->
                     <div class="row justify-content-center mb-3">
                         <a t-attf-href="/my2/sponsorships">

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -47,9 +47,7 @@ Page: My Compassion 2 Children Page
                 </div>
                 <!-- TEXT DESCRIPTION -->
                 <div class="single-column">
-                    <t t-call="theme_compassion_2025.TitleComponent">
-                        <t t-set="description">Hearts grow stronger with each act of love through your sponsorship.</t>
-                    </t>
+                    <p class="title-description text-low-black text-center mb-3">Hearts grow stronger with each act of love through your sponsorship.</p>
                     <!-- NEW SPONSORSHIP BUTTON -->
                     <div class="row justify-content-center mb-3">
                         <a t-attf-href="/my2/sponsorships">

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -46,7 +46,7 @@ Page: My Compassion 2 Children Page
                     </div>
                 </div>
                 <!-- TEXT DESCRIPTION -->
-                 <div class="single-column">
+                <div class="single-column">
                     <t t-call="theme_compassion_2025.TitleComponent">
                         <t t-set="description">Hearts grow stronger with each act of love through your sponsorship.</t>
                     </t>

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -24,20 +24,7 @@ Page: My Compassion 2 Children Page
                         <t t-set="color" t-value="'core-blue'" />
                         <t t-set="underline_color" t-value="'low-yellow'" />
                         <t t-set="show_underline" t-value="True" />
-                        <t t-set="description">Hearts grow stronger with each act of love through your sponsorship.</t>
                     </t>
-                    <!-- NEW SPONSORSHIP BUTTON -->
-                    <div class="row justify-content-center mb-3">
-                        <a t-attf-href="/my2/sponsorships">
-                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
-                                <t t-set="variation" t-value="'filled'" />
-                                <t t-set="color" t-value="'low-blue'" />
-                                <t t-set="text_color" t-value="'white'" />
-                                <t t-set="variant" t-value="'default'" />
-                                <t t-set="label">New sponsorship</t>
-                            </t>
-                        </a>
-                    </div>
                 </div>
                 <!-- ACTIVE SPONSORSHIPS CHILDREN-->
                 <div class="container-content d-flex flex-column align-items-center mt-4 mb-5">
@@ -56,6 +43,24 @@ Page: My Compassion 2 Children Page
                                 </div>
                             </t>
                         </div>
+                    </div>
+                </div>
+                <!-- TEXT DESCRIPTION -->
+                 <div class="single-column">
+                    <t t-call="theme_compassion_2025.TitleComponent">
+                        <t t-set="description">Hearts grow stronger with each act of love through your sponsorship.</t>
+                    </t>
+                    <!-- NEW SPONSORSHIP BUTTON -->
+                    <div class="row justify-content-center mb-3">
+                        <a t-attf-href="/my2/sponsorships">
+                            <t t-call="theme_compassion_2025.ThemedButtonComponent">
+                                <t t-set="variation" t-value="'filled'" />
+                                <t t-set="color" t-value="'low-blue'" />
+                                <t t-set="text_color" t-value="'white'" />
+                                <t t-set="variant" t-value="'default'" />
+                                <t t-set="label">New sponsorship</t>
+                            </t>
+                        </a>
                     </div>
                 </div>
                 <!-- TERMINATED SPONSORSHIPS CHILDREN -->


### PR DESCRIPTION
# My Sponsorships Page: Visual Hierarchy Improvement

## Purpose and Context

The goal of this PR is to improve the visual hierarchy of the **"My Sponsorships"** page based on UI feedback.

Previously, the block containing the thank-you message ("Hearts grow stronger...") and the button to create a new sponsorship was displayed at the top of the page. This placement distracted from the primary content: the list of active sponsorships.

This PR reorganizes the layout so users first see their ongoing sponsorships before being encouraged to take further action or read the closing message.

---

## Applied Changes and Improvements

### 1. Frontend – QWeb Template Reorganization

- **Block relocation**  
  The thank-you message and "Create a new sponsorship" button have been moved:
  - After the list of active sponsorships
  - Before the ended sponsorships section

- **Template structure update**  
  The block is now placed under the active sponsorships container in the QWeb template.

---

### 2. Visual Flow and UX

- **Improved content prioritization**  
  Users are first presented with their active sponsorships, reinforcing the primary purpose of the page.

- **Clear section separation**  
  The relocated block acts as a natural transition between active and ended sponsorships.

- **Conditional logic preserved**  
  The block remains positioned above the `ended_sponsorships` section, ensuring completed sponsorships consistently appear at the end of the page.