### PR TITLE
[T2839] - Remove calendar checkbox in communication settings

### DIFF
--- a/my_compassion/controllers/my2_user_settings.py
+++ b/my_compassion/controllers/my2_user_settings.py
@@ -199,7 +199,6 @@ class MyCompassionUserController(http.Controller):
             "tax_certificate",
             "letter_delivery_preference",
             "photo_delivery_preference",
-            "calendar",
             "birthday_reminder",
             "sponsorship_anniversary_card",
         }

--- a/my_compassion/templates/pages/my2_user_settings.xml
+++ b/my_compassion/templates/pages/my2_user_settings.xml
@@ -642,20 +642,6 @@ Injected data:
                                     <input
                                         type="checkbox"
                                         class="custom-control-input"
-                                        id="calendarCheck"
-                                        data-field="calendar"
-                                        t-att-checked="partner.calendar"
-                                    />
-                                    <label class="custom-control-label" for="calendarCheck">
-                                        I
-                                        would like to receive the Compassion
-                                        Calendar
-                                    </label>
-                                </div>
-                                <div class="custom-control custom-switch  mb-2">
-                                    <input
-                                        type="checkbox"
-                                        class="custom-control-input"
                                         id="birthdaysCheck"
                                         data-field="birthday_reminder"
                                         t-att-checked="partner.birthday_reminder"


### PR DESCRIPTION
# Removal of "Compassion Calendar" Communication Preference

## Problem Description

The **"Compassion Calendar"** communication preference remained across multiple layers of the application despite being obsolete and no longer used in any active delivery process.

This created unnecessary complexity and inconsistencies in partner communication settings.

---

## Justification and Context

This PR fully removes the obsolete communication preference, ensuring consistency across backend logic, database models, and user interfaces.

Analysis confirmed that the calendar distribution was **an old process** involving **physical calendar mailings**, which are no longer performed. No automated workflow or email template relied on this field.

---

## Applied Changes and Fixes

### Backend & Business Logic (Python)

- Removed the `calendar` boolean field from the `res.partner` model.  
- Cleaned up the `compute_inverse_no_physical_letter` method to remove calendar-related logic.  
- Updated the `set_partner_communication_settings` controller to remove `calendar` from allowed fields.

---

### Frontend & User Interface (XML)

- Removed the `calendar` field from Odoo partner and contact forms.  
- Removed `default_calendar` from context initialization.  
- Removed the calendar preference switch from the MyCompassion portal settings page.

---

## Related PRs

This set of improvements is complemented by a related PR in the **Compassion-switzerland** repository:

- PR: [[T2839] - Remove calendar checkbox in communication settings #1717](https://github.com/CompassionCH/compassion-switzerland/pull/1717)
