### PR TITLE
[T2782] Make phone number optional in user settings

### DIFF
--- a/my_compassion/controllers/my2_user_settings.py
+++ b/my_compassion/controllers/my2_user_settings.py
@@ -64,7 +64,7 @@ class MyCompassionUserController(http.Controller):
             "email": str,
         }
 
-        optional_fields = {"phone"}
+        optional_fields = {"phone", "mobile"}
 
         vals_to_update = {}
         errors = {}

--- a/my_compassion/controllers/my2_user_settings.py
+++ b/my_compassion/controllers/my2_user_settings.py
@@ -64,13 +64,15 @@ class MyCompassionUserController(http.Controller):
             "email": str,
         }
 
+        optional_fields = {"phone"}
+
         vals_to_update = {}
         errors = {}
         # Iterate through submitted data and validate it against the allowed fields.
         for field, value in post.items():
             if field in allowed_fields:
                 clean_value = (value or "").strip()
-                if not clean_value:
+                if not clean_value and field not in optional_fields:
                     errors[field] = "This field cannot be empty."
                 else:
                     try:


### PR DESCRIPTION
### Description:

In _Setting>Personal Information>Edit_ the user was forced to enter a Phone Number and a Mobile Phone Number. 
This PR allow the user to let the phone number field empty

### Technical:
Updates the `set_personal_info` controller method to allow the phone number field to be empty. Previously, all fields in the `allowed_fields` list were mandatory. This change introduces an `optional_fields` set to whitelist fields that can be cleared or left blank by the user.