### PR TITLE
[T2835] - Fix inconsistent footer margin for copyright reference

### DIFF
--- a/theme_compassion_2025/views/footer.xml
+++ b/theme_compassion_2025/views/footer.xml
@@ -51,7 +51,7 @@
                     <div class="container">
                         <div class="row align-middle">
                             <div class="col-lg-6">
-                                <p>
+                                <p class="pl-3">
                                     Copyright ©
                                     <span t-esc="datetime.datetime.now().year" />
                                     <span t-esc="res_company.name" />


### PR DESCRIPTION
## Description

Fixes the horizontal alignment of the copyright text in the footer.

---

## Changes Made

- **Horizontal alignment**: Added the `pl-3` class to the copyright `<p>` element to add spacing from the left edge.
- **Symmetry**: Ensures consistent spacing with right-side elements (Policies / Social links), which already use `pr-3`.
- **Layout stability**: Padding is applied directly to the `<p>` element instead of the column container to prevent layout wrapping and preserve the `col-lg-6` structure.

---

## Result

Footer spacing is now consistent and visually aligned with the contact elements above, with symmetrical left and right margins.