### PR TITLE
[T2855] - Impact trip procedure : upload criminal records

### DIFF
--- a/website_event_compassion/models/event_registration.py
+++ b/website_event_compassion/models/event_registration.py
@@ -386,19 +386,6 @@ class EventRegistration(models.Model):
                 ]
             )
 
-    def _compute_passport(self):
-        for registration in self:
-            attachment = self.env["ir.attachment"].search(
-                [
-                    ("name", "like", "Passport"),
-                    ("res_id", "=", registration.id),
-                    ("res_model", "=", self._name),
-                ],
-                limit=1,
-            )
-            registration.passport = attachment.datas
-            registration.passport_filename = attachment.name
-
     def _compute_surveys(self):
         user_input_obj = self.env["survey.user_input"]
         for registration in self:

--- a/website_event_compassion/models/event_registration.py
+++ b/website_event_compassion/models/event_registration.py
@@ -6,13 +6,11 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import base64
 import logging
 
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.http import request
 from odoo.tools import index_exists
-from odoo.tools.mimetypes import guess_mimetype
 
 from odoo.addons.website.models.website import slugify as slug
 

--- a/website_event_compassion/models/event_registration.py
+++ b/website_event_compassion/models/event_registration.py
@@ -138,9 +138,8 @@ class EventRegistration(models.Model):
         string="Emergency contact relation type",
     )
     birth_name = fields.Char()
-    passport = fields.Binary(compute="_compute_passport", inverse="_inverse_passport")
+    passport = fields.Binary(related="partner_id.passport", readonly=False)
     passport_number = fields.Char()
-    passport_filename = fields.Char(compute="_compute_passport")
     passport_expiration_date = fields.Date()
     survey_count = fields.Integer(compute="_compute_survey_count")
     invoice_count = fields.Integer(compute="_compute_invoice_count")
@@ -401,33 +400,6 @@ class EventRegistration(models.Model):
             )
             registration.passport = attachment.datas
             registration.passport_filename = attachment.name
-
-    def _inverse_passport(self):
-        attachment_obj = self.env["ir.attachment"].sudo()
-        for registration in self:
-            passport = registration.passport
-            if passport:
-                f_type = guess_mimetype(base64.decodebytes(passport), "/pdf").split(
-                    "/"
-                )[1]
-                name = f"Passport {registration.name}.{f_type}"
-                attachment_obj.create(
-                    {
-                        "res_model": self._name,
-                        "res_id": registration.id,
-                        "datas": passport,
-                        "name": name,
-                        "public": False,
-                    }
-                )
-            else:
-                attachment_obj.search(
-                    [
-                        ("name", "like", "Passport"),
-                        ("res_id", "=", registration.id),
-                        ("res_model", "=", self._name),
-                    ]
-                ).unlink()
 
     def _compute_surveys(self):
         user_input_obj = self.env["survey.user_input"]

--- a/website_event_compassion/models/res_partner.py
+++ b/website_event_compassion/models/res_partner.py
@@ -18,3 +18,13 @@ class ResPartner(models.Model):
         "Event registrations",
         readonly=False,
     )
+
+    passport = fields.Binary(attachment=True)
+    passport_name = fields.Char(compute="_compute_passport_name")
+
+    def _compute_passport_name(self):
+        for partner in self:
+            if partner.passport:
+                partner.passport_name = f"Passport_{partner.name}"
+            else:
+                partner.passport_name = False

--- a/website_event_compassion/views/event_registration_view.xml
+++ b/website_event_compassion/views/event_registration_view.xml
@@ -91,8 +91,7 @@
                 </group>
                 <group name="trip_2" string="Personal information">
                     <field name="birth_name" />
-                    <field name="passport_filename" invisible="1" />
-                    <field name="passport" filename="passport_filename" />
+                    <field name="passport" />
                     <field name="passport_number" />
                     <field name="passport_expiration_date" />
                     <field name="criminal_record" groups="child_protection.group_criminal_record" />

--- a/website_event_compassion/wizards/registration_form.py
+++ b/website_event_compassion/wizards/registration_form.py
@@ -19,10 +19,8 @@ class RegistrationForm(models.TransientModel):
         readonly=False,
         default=False,
     )
-    passport = fields.Binary(related="registration_id.passport", readonly=False)
-    criminal_record = fields.Binary(
-        related="registration_id.criminal_record", readonly=False
-    )
+    passport = fields.Binary(string="Passport")
+    criminal_record = fields.Binary(string="Criminal Record")
     comments = fields.Text()
 
     @api.model_create_multi

--- a/website_event_compassion/wizards/registration_form.py
+++ b/website_event_compassion/wizards/registration_form.py
@@ -31,9 +31,9 @@ class RegistrationForm(models.TransientModel):
         for form in forms:
             docs_to_save = {}
             if form.passport:
-                docs_to_save['passport'] = form.passport
+                docs_to_save["passport"] = form.passport
             if form.criminal_record:
-                docs_to_save['criminal_record'] = form.criminal_record
+                docs_to_save["criminal_record"] = form.criminal_record
             if docs_to_save:
                 form.registration_id.sudo().write(docs_to_save)
 

--- a/website_event_compassion/wizards/registration_form.py
+++ b/website_event_compassion/wizards/registration_form.py
@@ -29,8 +29,16 @@ class RegistrationForm(models.TransientModel):
     def create(self, vals_list):
         forms = super().create(vals_list)
         for form in forms:
+            docs_to_save = {}
+            if form.passport:
+                docs_to_save['passport'] = form.passport
+            if form.criminal_record:
+                docs_to_save['criminal_record'] = form.criminal_record
+            if docs_to_save:
+                form.registration_id.sudo().write(docs_to_save)
+
             if form.comments:
-                form.registration_id.message_post(
+                form.registration_id.sudo().message_post(
                     body=form.comments,
                     author_id=form.registration_id.partner_id.id,
                     subtype_xmlid="mail.mt_comment",


### PR DESCRIPTION
# Criminal Record Save Failure Resolution

## Purpose and Context

The goal of this PR is to fix a critical issue preventing users from updating their **Criminal Record** via the MyCompassion portal.

Due to Odoo security constraints and inconsistent document handling, uploads were failing when registrations were in the **Attended** state. In some cases, this also caused unstable registration statuses and the disappearance of events from the **My Events** section.

This PR should be reviewed together with a related PR, as both contribute to stabilizing the document upload and event registration workflows.

---

## Applied Changes and Improvements

### 1. Portal Security and Save Reliability

- **Secure write with `sudo`**  
  Document saving in `event.registration.form` now uses  
  `form.registration_id.sudo().write(docs_to_save)`.

- **Result**  
  Documents are saved with sufficient privileges, preventing access errors, redirection crashes, and unintended status changes. The **Attended** status is preserved.

---

### 2. Document Management Standardization

- **Unified handling**  
  Passport and Criminal Record are now managed in an identical and consistent way.

- **Technical debt removal**  
  Complex `compute` / `inverse` logic for Passport has been removed.  
  Both documents are now standard `Binary` fields with `attachment=True` on `res.partner`.

- **Single source of truth**  
  Documents are physically attached to the partner (contact).  
  Event registrations access them through related fields.

- **XML cleanup**  
  Backend views were simplified by removing obsolete technical fields (e.g. `passport_filename`).

---

### 3. Validation and Testing

- **Portal upload testing**  
  Documents were uploaded using a real participant account for the Impact Trip in the Dominican Republic.

- **Technical verification**  
  Uploaded documents are visible under  
  `Settings → Technical → Attachments` as *Passport* and *Criminal Record*.

- **Data integrity**  
  Each attachment correctly references the related partner in the **Attached To** field.

---

## Outcome

- Criminal Record and Passport uploads are stable and reliable.
- Event registrations remain visible, with the **Attended** status preserved.
- The codebase is cleaner, standardized, and easier to maintain.

---

## Related PRs

This set of improvements is complemented by a related PR in the **Compassion-modules** repository:

- PR: [[T2855] - Impact trip procedure : upload criminal records #2065](https://github.com/CompassionCH/compassion-modules/pull/2065)