### PR TITLE
T2896 JS files are not translated

### DIFF
--- a/my_compassion/models/__init__.py
+++ b/my_compassion/models/__init__.py
@@ -25,4 +25,5 @@ from . import (
     my2_website_route,
     compassion_child,
     contracts,
+    ir_http,
 )

--- a/my_compassion/models/ir_http.py
+++ b/my_compassion/models/ir_http.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/my_compassion/models/ir_http.py
+++ b/my_compassion/models/ir_http.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
+        return mods + ['my_compassion']

--- a/my_compassion/models/ir_http.py
+++ b/my_compassion/models/ir_http.py
@@ -1,13 +1,12 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
 
 
 class IrHttp(models.AbstractModel):
-    _inherit = 'ir.http'
+    _inherit = "ir.http"
 
     @classmethod
     def _get_translation_frontend_modules_name(cls):
         mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
-        return mods + ['my_compassion']
+        return mods + ["my_compassion"]


### PR DESCRIPTION
## Problem description
There is a problem regarding the translation of JS files. Currently they are using the _t(...) to translate string , which is correct.
 The strings are well fetched by the odoo string crawler, you can see them on the generated po files. The translations are also set in the Odoo back-end. However, when a user goes in the MC2 website, they cannot see the translations. 

Here is some case you can test : 
- On the letters page, try to share one and you'll get a pop-up. If you are not using https you'll get "Sharing is not supported in this browser. Please share your letter manually." Never translated. 
- When writing a new letter, try to save a draft, you'll get an untranslated popup again. 
- When writing a new letter, the button "select a template" is translated, click "Start Over", "select a template"  is no longer translated. 


## The Fix 

The problem was that the JS translation dictionary didn't contain the my_compassion terms. Overloading some ir_http stuff fixed the problem. 
 
 