### PR TITLE
[T2888] - Remove verse after "Ended Sponsorship"

### DIFF
--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -70,10 +70,6 @@ Would you like to bring hope to another child?
                             <t t-set="color" t-value="'core-blue'" />
                             <t t-set="underline_color" t-value="'low-yellow'" />
                             <t t-set="show_underline" t-value="True" />
-                            <t t-set="description">
-                                Because of the Lord’s great love we are not consumed, for his compassions never fail.
-                                They are new every morning; great is your faithfulness. Lamentations 3.22-23
-                            </t>
                         </t>
                     </div>
                     <div class="container-content d-flex flex-column align-items-center mb-5">


### PR DESCRIPTION
# Removal of Static Verse from My sponsorship Page

## Purpose and Context

This PR updates the user interface of the **"My sponsorship"** page (`/my2/children`).  
The static biblical verse (Lamentations 3:22–23) previously displayed at the bottom of the page is no longer required in the current design.

---

## Applied Changes and Improvements

### 1. XML Template Update

- **Verse removal**  
  The `<t t-set="description">` block containing the static verse has been removed from  
  `my_compassion/templates/pages/my2_children.xml`.