### PR TITLE
T2900 Compassion 2.0 website margin issue

### DIFF
--- a/my_compassion/templates/login_template.xml
+++ b/my_compassion/templates/login_template.xml
@@ -55,6 +55,13 @@
             </p>
         </xpath>
     </template>
+    <template id="password_field" inherit_id="web.login">
+        <xpath expr="//input[@name='password']" position="inside">
+            <i class="fa fa-eye" id="eye_password" style="position: absolute; right: 10px; top: 60%;cursor: pointer;" />
+        </xpath>
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/my_compassion/static/src/js/show_password.js" />
+        </xpath>
     </template>
     <template id="custom_assets" inherit_id="website.assets_frontend">
         <xpath expr="//link[last()]" position="after">

--- a/my_compassion/templates/login_template.xml
+++ b/my_compassion/templates/login_template.xml
@@ -55,13 +55,6 @@
             </p>
         </xpath>
     </template>
-    <template id="password_field" inherit_id="web.login">
-        <xpath expr="//input[@name='password']" position="inside">
-            <i class="fa fa-eye" id="eye_password" style="position: absolute; right: 10px; top: 60%;cursor: pointer;" />
-        </xpath>
-        <xpath expr="." position="inside">
-            <script type="text/javascript" src="/my_compassion/static/src/js/show_password.js" />
-        </xpath>
     </template>
     <template id="custom_assets" inherit_id="website.assets_frontend">
         <xpath expr="//link[last()]" position="after">

--- a/theme_compassion_2025/static/src/scss/base/_base.scss
+++ b/theme_compassion_2025/static/src/scss/base/_base.scss
@@ -21,6 +21,6 @@ body {
     background-color: var(--pure-white);
 }
 #wrapwrap {
-    width: 100% !important;
-    overflow-x: hidden !important;
+    width: 100%;
+    overflow-x: hidden;
 }

--- a/theme_compassion_2025/static/src/scss/base/_base.scss
+++ b/theme_compassion_2025/static/src/scss/base/_base.scss
@@ -20,3 +20,7 @@ body {
     font-size: 16px;
     background-color: var(--pure-white);
 }
+#wrapwrap {
+    width: 100% !important;
+    overflow-x: hidden !important;
+}


### PR DESCRIPTION
## Summary

This PR changes the wrapper's style of the website so that no useless horizontal scroll appear at the bottom of the page. 

## Before 
<img width="1153" height="1043" alt="download (2)" src="https://github.com/user-attachments/assets/04529dc7-4ce7-4b7c-8f29-4c0aa5bfb9f4" />


Try it, you'll adopt it.
