### PR TITLE
T2856 inconsistent logic for duplicate donations in cart & missing aggregation

### DIFF
--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -80,18 +80,24 @@ class MyCompassionDonationsController(CustomerPortal):
         )
         # See if an existing row for the same product and the same child exist
         # If it's the case, just increment the amount of the donation
-        matching_lines = (
-            request.env["sale.order.line"]
-            .sudo()
-            .search(
-                [
-                    ("order_id", "=", order.id),
-                    ("product_id.product_tmpl_id", "=", product_template.id),
-                    ("gift_recipient_id", "=", int(post.get("recipient"))),
-                ]
+        domain = [
+            ("order_id", "=", order.id),
+            ("product_id.product_tmpl_id", "=", product_template.id),
+        ]
+        if current_order_line_fields.get("is_gift") and current_order_line_fields.get(
+            "gift_recipient_id"
+        ):
+            domain.append(
+                (
+                    "gift_recipient_id",
+                    "=",
+                    int(current_order_line_fields.get("gift_recipient_id")),
+                )
             )
-        )
-        # Aggregate the matching line if necessary
+
+        matching_lines = request.env["sale.order.line"].sudo().search(domain)
+
+        # Aggregate the matching lines if necessary
         if matching_lines:
             aggregated_line = matching_lines[0]
             aggregated_price = aggregated_line.price_unit

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -83,6 +83,7 @@ class MyCompassionDonationsController(CustomerPortal):
         domain = [
             ("order_id", "=", order.id),
             ("product_id.product_tmpl_id", "=", product_template.id),
+            ("frequency", "=", current_order_line_fields.get("frequency")),
         ]
         if current_order_line_fields.get("is_gift") and current_order_line_fields.get(
             "gift_recipient_id"

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -75,21 +75,46 @@ class MyCompassionDonationsController(CustomerPortal):
 
         # Get current cart content
         order = request.website.sale_get_order(force_create=True)
-
-        # Add product to the cart
-        order.write(
-            {
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        self._extract_donation_order_line_fields(
-                            product_template, post
-                        ),
-                    )
-                ]
-            }
+        current_order_line_fields = self._extract_donation_order_line_fields(
+            product_template, post
         )
+        # See if an existing row for the same product and the same child exist
+        # If it's the case, just increment the amount of the donation
+        matching_lines = (
+            request.env["sale.order.line"]
+            .sudo()
+            .search(
+                [
+                    ("order_id", "=", order.id),
+                    ("product_id.product_tmpl_id", "=", product_template.id),
+                    ("gift_recipient_id", "=", int(post.get("recipient"))),
+                ]
+            )
+        )
+        # Agregate the matching line if necessary
+        if matching_lines:
+            aggregated_line = matching_lines[0]
+            aggregated_price = aggregated_line.price_unit
+            for line in matching_lines[1:]:
+                aggregated_price += line.price_unit
+                line.unlink()
+            # Add to the aggregated price the one of the current donation
+            aggregated_price += current_order_line_fields["price_unit"]
+            aggregated_line.price_unit = aggregated_price
+
+        else:
+            # Add product to the cart
+            order.write(
+                {
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            current_order_line_fields,
+                        )
+                    ]
+                }
+            )
 
     @http.route(
         "/my2/gifts/edit",

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -91,7 +91,7 @@ class MyCompassionDonationsController(CustomerPortal):
                 ]
             )
         )
-        # Agregate the matching line if necessary
+        # Aggregate the matching line if necessary
         if matching_lines:
             aggregated_line = matching_lines[0]
             aggregated_price = aggregated_line.price_unit

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -72,13 +72,13 @@ class MyCompassionDonationsController(CustomerPortal):
         # Make sure the product is available
         if not product_template.activate_for_my_compassion:
             raise NotFound()
-
-        # Get current cart content
-        order = request.website.sale_get_order(force_create=True)
+        # Extract order line for the current product
         current_order_line_fields = self._extract_donation_order_line_fields(
             product_template, post
         )
-        # See if an existing row for the same product and the same child exist
+        # Get current cart content
+        order = request.website.sale_get_order(force_create=True)
+        # See if an existing row for the same product and the same sponsorship exists
         # If it's the case, just increment the amount of the donation
         domain = [
             ("order_id", "=", order.id),
@@ -94,7 +94,7 @@ class MyCompassionDonationsController(CustomerPortal):
                     int(current_order_line_fields.get("gift_recipient_id")),
                 )
             )
-
+        # Order lines for the same product (same sponsorship, same product)
         matching_lines = request.env["sale.order.line"].sudo().search(domain)
 
         # Aggregate the matching lines if necessary
@@ -109,7 +109,7 @@ class MyCompassionDonationsController(CustomerPortal):
             aggregated_line.price_unit = aggregated_price
 
         else:
-            # Add product to the cart
+            # Add the new product to the cart
             order.write(
                 {
                     "order_line": [

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -303,7 +303,7 @@ class MyCompassionDonationsController(CustomerPortal):
     )
     def my2_render_add_a_gift_page(self, **kwargs):
         """
-        Renders the add a gift page to quickly add a gift to the gift package.
+        Renders the add a gift page to add a gift to the gift package.
         return: An HTTP response containing a rendered template with the add a
         gift page.
         """

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -101,10 +101,12 @@ class MyCompassionDonationsController(CustomerPortal):
         # Aggregate the matching lines if necessary
         if matching_lines:
             aggregated_line = matching_lines[0]
-            aggregated_price = aggregated_line.price_unit
-            for line in matching_lines[1:]:
-                aggregated_price += line.price_unit
-                line.unlink()
+            aggregated_price = sum(line.price_unit for line in matching_lines)
+
+            # Unlink all but the first one in a single call
+            if len(matching_lines) > 1:
+                matching_lines[1:].unlink()
+
             # Add to the aggregated price the one of the current donation
             aggregated_price += current_order_line_fields["price_unit"]
             aggregated_line.price_unit = aggregated_price

--- a/my_compassion/controllers/my2_donations.py
+++ b/my_compassion/controllers/my2_donations.py
@@ -307,16 +307,13 @@ class MyCompassionDonationsController(CustomerPortal):
         return: An HTTP response containing a rendered template with the add a
         gift page.
         """
-        # Exclude fund donation that are already in the user's gift package
         order = request.website.sale_get_order(force_create=True)
-        product_template_ids_in_cart = order.order_line.product_id.product_tmpl_id.ids
         products = request.env["product.template"].search(
             [
-                "&",
                 ("activate_for_my_compassion", "=", True),
                 "|",
                 ("my_compassion_donation_type", "=", "gift"),
-                ("id", "not in", product_template_ids_in_cart),
+                ("my_compassion_donation_type", "=", "fund"),
             ]
         )
 


### PR DESCRIPTION
## Summary 
Note: In the the [Task description](http://erp.compassion.ch/web#id=3448&model=project.task&view_type=form&cids=1&menu_id=2029) @ecino chose the option A.

This PR Fixes the following problems : 

### Issues 
1) When a user takes multiple time the same product (and potentially to the same child), a new line in the cart was created. 
2) Once a user added a product in the cart, they cannot longer see it in the gift/fund proposition

### Fixes 
1) The 1st issue is solved by aggregating the amount of the product. 
2) For the 2nd just remove a filter.