### PR TITLE
T2927 child info card is not well translated change male/female to boy/girl

### DIFF
--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -71,8 +71,8 @@
                         <t t-esc="child.age" />
                         years old
                         <i class="icon-user01 bg-low-yellow mx-1" />
-                        <t t-if="child.gender == 'M'">Male</t>
-                        <t t-elif="child.gender == 'F'">Female</t>
+                        <t t-if="child.gender == 'M'">Boy</t>
+                        <t t-elif="child.gender == 'F'">Girl</t>
                         <t t-else="">Not specified</t>
                     </div>
                     <div>

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -77,7 +77,7 @@
                     </div>
                     <div>
                         <i class="icon-map01 bg-low-yellow mx-1" />
-                        <t t-esc="child.field_office_id.name" />
+                        <span t-field="child.field_office_id.country_id.name" />
                     </div>
                 </div>
                 <!-- Profile Button -->

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -51,11 +51,17 @@
                         <span class="border-bottom border-2 border-high-orange">
                             <t t-if="sponsorship_end_date">
                                 Sponsorship terminated on
-                                <t t-esc="sponsorship_end_date.strftime('%d %B %Y')" />
+                                <t
+                                    t-esc="sponsorship_end_date"
+                                    t-options="{'widget': 'date', 'format': 'dd MMMM yyyy'}"
+                                />
                             </t>
                             <t t-elif="latest_correspondence">
                                 Last contact
-                                <t t-esc="latest_correspondence.write_date.strftime('%d %B %Y')" />
+                                <t
+                                    t-esc="latest_correspondence.write_date"
+                                    t-options="{'widget': 'date', 'format': 'dd MMMM yyyy'}"
+                                />
                             </t>
                             <t t-else="">No correspondences</t>
                         </span>

--- a/my_compassion/templates/pages/my2_sponsorships.xml
+++ b/my_compassion/templates/pages/my2_sponsorships.xml
@@ -108,7 +108,7 @@ Page: My Compassion 2 Sponsorships Page
                                     <option value="">Select country</option>
                                     <t t-foreach="countries" t-as="country">
                                         <option t-att-value="country.field_office_id">
-                                            <t t-esc="country.name" />
+                                            <t t-esc="country.country_id.name" />
                                         </option>
                                     </t>
                                 </t>


### PR DESCRIPTION
## Summary 

This PR fixes 3 things:

### 1) The country name are now translated

In the Child pool and in the Child card, the country names are now translated.

### 2) The term male/female in the child info card is now replacec by boy/girl  

### 3) The dates like "Last contact ..." in the child info card are now translated

### Note : in this picture "Last contact" is not translated, this is because my db is evil...

<img width="433" height="496" alt="image" src="https://github.com/user-attachments/assets/b9e59de1-e6b2-4853-83e2-30370057581c" />

