### PR TITLE
[T2902] Allow users with portal_sponsorships = "all_info" to access the letter info. of their pay_only sponsorship

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -265,10 +265,16 @@ class MyCompassionChildrenController(WebsiteChild):
         # To keep a list of the latest correspondence with each sponsored child:
         latest_corr_by_child = {}
         correspondences_table = request.env["correspondence"].sudo()
-
+        children_sponsored_by_partner = partner.sponsorship_ids.child_id
         received_correspondences = correspondences_table.search(
             [
+                "|",
                 ("partner_id", "=", partner.id),
+                (
+                    "child_id",
+                    "in",
+                    children_sponsored_by_partner.filtered("can_i_write_letter").ids,
+                ),
                 ("direction", "=", "Beneficiary To Supporter"),
             ],
             order="create_date desc",

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -70,7 +70,7 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         # Authorized means either the partner is the direct correspondent or the sponsor
         # has read-write rights on the letters of the child (eg: if the partner is the
         # parent of young Write-only sponsors, in this case the parent res_partner has
-        # portal_info = all_info)
+        # portal_sponsorships = all_info)
         filter_domain = [
             "|",
             ("partner_id", "=", partner.id),

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -65,7 +65,14 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         to_date = date(year_to, month_to, last_day)
 
         # Build the domain of the filtering of the letters
+
+        # Matches letters sent to the partner or their authorized sponsored children
+        # Authorized means either the partner is the direct correspondent or the sponsor
+        # has read-write rights on the letters of the child (eg: if the partner is the
+        # parent of young Write-only sponsors, in this case the parent res_partner has
+        # portal_info = all_info)
         filter_domain = [
+            "|",
             ("partner_id", "=", partner.id),
             (
                 "child_id",


### PR DESCRIPTION
## Summary 
This PR basically allows users with portal_info = "all_info" to access letters of their pay_only sponsorship.


## Current situation : 
- Currently the timeline (letters + gifts ..etc ) is shown to so called authorized_partner (see `_get_authorized_partner_ids`). Which is a list that includes the partner correspondent of the letter AND the **Pay Only** sponsors if the portal settings allows (portal_sponsorships = 'all_info')   
- However, the set of partner able to see letters are note the same when rendering the letter pages see `/my2/children/letters` this is why PayOnly sponsors with portal_sponsorships = 'all_info' couldn't see the letters on this page but on the timeline they could. 


## Solution 

Just Fix the filter of the correspondence to include portal_info = "all_info" case. 

## How to test

The following user with ID = 13635 (partner id = `48323`) is apparently the parent of the two following partners  : `48326` and `48325` . These two write letters to their sponsored child. The parent has 2 PayOnly sponsorships (one for each child) and has portal_sponsorships = "all_info". 

- You can toggle the portal_sponsorships value between "all" and "all_info" to see the difference.   