### PR TITLE
T2949   child detail school terms issue

### DIFF
--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -24,11 +24,9 @@ class WebsiteHomeRedirect(Website):
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
 
-        if request.website == request.env.ref(
-            "my_compassion.my2_website", raise_if_not_found=False
-        ):
+        if request.website == request.env.ref("my_compassion.my2_website"):
             if request.session.uid:
                 return request.redirect("/my2/dashboard")
             else:
                 return request.redirect("/web/login")
-        return super().index(*args, **kw)
+        return super().home(*args, **kw)

--- a/my_compassion/controllers/my2_home_redirect.py
+++ b/my_compassion/controllers/my2_home_redirect.py
@@ -24,9 +24,11 @@ class WebsiteHomeRedirect(Website):
         `my2_login.py` handles the redirection from the login page to the dashboard.
         """
 
-        if request.website == request.env.ref("my_compassion.my2_website"):
+        if request.website == request.env.ref(
+            "my_compassion.my2_website", raise_if_not_found=False
+        ):
             if request.session.uid:
                 return request.redirect("/my2/dashboard")
             else:
                 return request.redirect("/web/login")
-        return super().home(*args, **kw)
+        return super().index(*args, **kw)

--- a/my_compassion/models/compassion_child.py
+++ b/my_compassion/models/compassion_child.py
@@ -68,3 +68,20 @@ class CompassionChild(models.Model):
             child.can_i_make_gift = (
                 sponsorship.can_make_gift and partner == sponsorship.partner_id
             )
+
+    def get_education_status_data(self):
+        """
+        Returns a dictionary with education status
+        """
+        self.ensure_one()
+
+        subject_count = len(self.subject_ids)
+        is_enrolled = self.education_level and self.education_level != "Not Enrolled"
+
+        return {
+            "level": self.translate("education_level"),
+            "is_enrolled": is_enrolled,
+            "subjects_str": self.get_list("subject_ids.value"),
+            "has_multiple_subjects": subject_count > 1,
+            "has_subjects": subject_count > 0,
+        }

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -133,10 +133,14 @@
                                         <t t-esc="compassion_child.get_list('hobby_ids.value')" />
                                     </p>
                                 </div>
-
-                                <t t-set="school_education_level" t-value="compassion_child.translate('education_level').lower()"/>
-                                <t t-set="school_prefered_subject" t-value="compassion_child.get_list('subject_ids.value')"/>
-
+                                <t
+                                    t-set="school_education_level"
+                                    t-value="compassion_child.translate('education_level').lower()"
+                                />
+                                <t
+                                    t-set="school_prefered_subject"
+                                    t-value="compassion_child.get_list('subject_ids.value')"
+                                />
                                 <div class="child-info-item d-flex align-items-center" t-if="school_education_level">
                                     <div class="frame bg-mid-pink mr-2">
                                         <i class="icon icon-graduation-hat02 text-pure-white m-2" />
@@ -147,8 +151,8 @@
                                             <t t-esc="school_education_level" />
                                         </span>
                                         <t t-if="school_prefered_subject">
-                                        <span>and my favourite subjects are</span>
-                                        <t t-esc="school_prefered_subject" />
+                                            <span>and my favourite subjects are</span>
+                                            <t t-esc="school_prefered_subject" />
                                         </t>
                                     </p>
                                 </div>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -133,8 +133,14 @@
                                         <t t-esc="compassion_child.get_list('hobby_ids.value')" />
                                     </p>
                                 </div>
-                                <t t-set="child_education_data" t-value="compassion_child.get_education_status_data()" />
-                                <div class="child-info-item d-flex align-items-center" t-if="child_education_data.get('level')">
+                                <t
+                                    t-set="child_education_data"
+                                    t-value="compassion_child.get_education_status_data()"
+                                />
+                                <div
+                                    class="child-info-item d-flex align-items-center"
+                                    t-if="child_education_data.get('level')"
+                                >
                                     <div class="frame bg-mid-pink mr-2">
                                         <i class="icon icon-graduation-hat02 text-pure-white m-2" />
                                     </div>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -133,17 +133,26 @@
                                         <t t-esc="compassion_child.get_list('hobby_ids.value')" />
                                     </p>
                                 </div>
-                                <div class="child-info-item d-flex align-items-center">
+                                <t t-set="child_education_data" t-value="compassion_child.get_education_status_data()" />
+                                <div class="child-info-item d-flex align-items-center" t-if="child_education_data.get('level')">
                                     <div class="frame bg-mid-pink mr-2">
                                         <i class="icon icon-graduation-hat02 text-pure-white m-2" />
                                     </div>
                                     <p class="child-info-text">
-                                        I'm in
-                                        <span class="text-mid-pink font-weight-bold">
-                                            <t t-esc="compassion_child.translate('education_level')" />
-                                        </span>
-                                        <span>and my favourite subjects are</span>
-                                        <t t-esc="compassion_child.get_list('subject_ids.value')" />
+                                        <t t-if="child_education_data['is_enrolled']">
+                                            I'm in
+                                            <span class="text-mid-pink font-weight-bold">
+                                                <t t-esc="child_education_data['level']" />
+                                            </span>
+                                            <t t-if="child_education_data['has_subjects']">
+                                                <span t-if="child_education_data['has_multiple_subjects']">
+                                                    and my favourite subjects are
+                                                </span>
+                                                <span t-else="">and my favourite subject is</span>
+                                                <t t-esc="child_education_data['subjects_str']" />
+                                            </t>
+                                        </t>
+                                        <t t-else="">I'm not enrolled in school</t>
                                     </p>
                                 </div>
                             </div>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -134,26 +134,41 @@
                                     </p>
                                 </div>
                                 <t
-                                    t-set="school_education_level"
-                                    t-value="compassion_child.translate('education_level').lower()"
+                                    t-set="child_school_education_level"
+                                    t-value="(compassion_child.translate('education_level') or '').lower()"
+                                />
+                                <t
+                                    t-set="child_is_enrolled_at_school"
+                                    t-value="compassion_child.education_level and compassion_child.education_level != 'Not Enrolled'"
                                 />
                                 <t
                                     t-set="school_prefered_subject"
                                     t-value="compassion_child.get_list('subject_ids.value')"
                                 />
-                                <div class="child-info-item d-flex align-items-center" t-if="school_education_level">
+                                <div
+                                    class="child-info-item d-flex align-items-center"
+                                    t-if="child_school_education_level"
+                                >
                                     <div class="frame bg-mid-pink mr-2">
                                         <i class="icon icon-graduation-hat02 text-pure-white m-2" />
                                     </div>
                                     <p class="child-info-text">
-                                        I'm in
-                                        <span class="text-mid-pink font-weight-bold">
-                                            <t t-esc="school_education_level" />
-                                        </span>
-                                        <t t-if="school_prefered_subject">
-                                            <span>and my favourite subjects are</span>
-                                            <t t-esc="school_prefered_subject" />
+                                        <t t-if="child_is_enrolled_at_school">
+                                            I'm in
+                                            <span class="text-mid-pink font-weight-bold">
+                                                <t t-esc="child_school_education_level" />
+                                            </span>
+                                            <t t-if="school_prefered_subject">
+                                                <span
+                                                    t-if="',' in school_prefered_subject or ' and ' in school_prefered_subject"
+                                                >
+                                                    and my favourite subjects are
+                                                </span>
+                                                <span t-else="">and my favourite subject is</span>
+                                                <t t-esc="school_prefered_subject" />
+                                            </t>
                                         </t>
+                                        <t t-else="">I'm not enrolled in school</t>
                                     </p>
                                 </div>
                             </div>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -135,7 +135,7 @@
                                 </div>
                                 <t
                                     t-set="child_school_education_level"
-                                    t-value="(compassion_child.translate('education_level') or '').lower()"
+                                    t-value="(compassion_child.translate('education_level') or '')"
                                 />
                                 <t
                                     t-set="child_is_enrolled_at_school"

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -133,17 +133,23 @@
                                         <t t-esc="compassion_child.get_list('hobby_ids.value')" />
                                     </p>
                                 </div>
-                                <div class="child-info-item d-flex align-items-center">
+
+                                <t t-set="school_education_level" t-value="compassion_child.translate('education_level').lower()"/>
+                                <t t-set="school_prefered_subject" t-value="compassion_child.get_list('subject_ids.value')"/>
+
+                                <div class="child-info-item d-flex align-items-center" t-if="school_education_level">
                                     <div class="frame bg-mid-pink mr-2">
                                         <i class="icon icon-graduation-hat02 text-pure-white m-2" />
                                     </div>
                                     <p class="child-info-text">
                                         I'm in
                                         <span class="text-mid-pink font-weight-bold">
-                                            <t t-esc="compassion_child.translate('education_level')" />
+                                            <t t-esc="school_education_level" />
                                         </span>
+                                        <t t-if="school_prefered_subject">
                                         <span>and my favourite subjects are</span>
-                                        <t t-esc="compassion_child.get_list('subject_ids.value')" />
+                                        <t t-esc="school_prefered_subject" />
+                                        </t>
                                     </p>
                                 </div>
                             </div>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -133,42 +133,17 @@
                                         <t t-esc="compassion_child.get_list('hobby_ids.value')" />
                                     </p>
                                 </div>
-                                <t
-                                    t-set="child_school_education_level"
-                                    t-value="(compassion_child.translate('education_level') or '')"
-                                />
-                                <t
-                                    t-set="child_is_enrolled_at_school"
-                                    t-value="compassion_child.education_level and compassion_child.education_level != 'Not Enrolled'"
-                                />
-                                <t
-                                    t-set="school_prefered_subject"
-                                    t-value="compassion_child.get_list('subject_ids.value')"
-                                />
-                                <div
-                                    class="child-info-item d-flex align-items-center"
-                                    t-if="child_school_education_level"
-                                >
+                                <div class="child-info-item d-flex align-items-center">
                                     <div class="frame bg-mid-pink mr-2">
                                         <i class="icon icon-graduation-hat02 text-pure-white m-2" />
                                     </div>
                                     <p class="child-info-text">
-                                        <t t-if="child_is_enrolled_at_school">
-                                            I'm in
-                                            <span class="text-mid-pink font-weight-bold">
-                                                <t t-esc="child_school_education_level" />
-                                            </span>
-                                            <t t-if="school_prefered_subject">
-                                                <span
-                                                    t-if="',' in school_prefered_subject or ' and ' in school_prefered_subject"
-                                                >
-                                                    and my favourite subjects are
-                                                </span>
-                                                <span t-else="">and my favourite subject is</span>
-                                                <t t-esc="school_prefered_subject" />
-                                            </t>
-                                        </t>
-                                        <t t-else="">I'm not enrolled in school</t>
+                                        I'm in
+                                        <span class="text-mid-pink font-weight-bold">
+                                            <t t-esc="compassion_child.translate('education_level')" />
+                                        </span>
+                                        <span>and my favourite subjects are</span>
+                                        <t t-esc="compassion_child.get_list('subject_ids.value')" />
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary 
This PR fixes the following things on the child scholarship status. 
1) If the education_level is null in the DB -> Display nothing (Not even the icon)
2) If the education_level is not null but the favourite subject list list is empty -> Don't display "My favourite subject is..."
3) If there are more than one favourite subject "My favourite subject IS " ->  "My favourite subjectS ARE " 
4) If the child is not enrolled in school (written in the db "Not Enrolled") -> Display "I'm not enrolled in school"
<img width="897" height="315" alt="image" src="https://github.com/user-attachments/assets/3985bfa1-15a3-47ec-b193-e6c0f339ae4c" />
<img width="897" height="315" alt="image" src="https://github.com/user-attachments/assets/cad2b979-802a-4052-9659-6166fe7a20fa" />
<img width="897" height="315" alt="image" src="https://github.com/user-attachments/assets/67bbf138-dd23-40de-afd0-552a556ed9bc" />

<img width="897" height="315" alt="image" src="https://github.com/user-attachments/assets/f7b506f2-22c4-4fa1-98b0-0f4d1c4909f4" />


