### PR TITLE
T2950 Remove space between My and Compassion in the dashboard

### DIFF
--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -31,7 +31,7 @@ Page: My Compassion 2 Dashboard Page
                         <h1 class="text-pure-white">
                             Welcome to
                             <br />
-                            <span class="text-low-yellow">My</span>
+                            <span class="text-low-yellow mr-n1">My</span>
                             Compassion
                         </h1>
                     </div>


### PR DESCRIPTION
This PR removes the  space between My and Compassion in the dashboard while keeping the yellow color on the "My"
<img width="213" height="82" alt="image" src="https://github.com/user-attachments/assets/2b19591e-4bb7-43bc-aada-dc63f91ac4d6" />
