### PR TITLE
T2964 Letters arrival date are wrong and displayed even if being on translation

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -148,7 +148,11 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     c.direction AS metadata,
-                    c.sent_date AS timeline_date,
+                    -- Logic: Use write_date for Supporter->Beneficiary, otherwise sent_date
+                    CASE 
+                        WHEN c.direction = 'Supporter To Beneficiary' THEN c.status_date 
+                        ELSE c.sent_date 
+                    END AS timeline_date,
                     CASE
                         WHEN c.direction = 'Beneficiary To Supporter'
                         THEN %(title_corr_wrote)s
@@ -158,7 +162,12 @@ class MyCompassionChildrenController(WebsiteChild):
                 FROM correspondence c
                 WHERE c.child_id = %(child_id)s
                   AND c.partner_id = ANY(%(partner_ids)s)
-                  AND c.state = 'Published to Global Partner'
+                  -- Updated Filtering Logic
+                  AND (
+                      (c.state = 'Published to Global Partner' AND c.direction = 'Beneficiary To Supporter')
+                      OR
+                      (c.state = 'Printed and sent to ICP' AND c.direction = 'Supporter To Beneficiary')
+                  )
 
                 UNION ALL
 
@@ -214,10 +223,9 @@ class MyCompassionChildrenController(WebsiteChild):
                   AND rc.start_date IS NOT NULL
 
             ) AS timeline
-            ORDER BY timeline_date DESC 
+            ORDER BY timeline_date DESC
             LIMIT %(limit)s OFFSET %(offset)s
         """
-
         params = {
             "child_id": child_id,
             "partner_ids": partner_ids,

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -148,7 +148,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     c.direction AS metadata,
-                    c.create_date,
+                    c.sent_date AS timeline_date,
                     CASE
                         WHEN c.direction = 'Beneficiary To Supporter'
                         THEN %(title_corr_wrote)s
@@ -158,6 +158,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 FROM correspondence c
                 WHERE c.child_id = %(child_id)s
                   AND c.partner_id = ANY(%(partner_ids)s)
+                  AND c.state = 'Published to Global Partner'
 
                 UNION ALL
 
@@ -167,7 +168,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     s.amount::text AS amount,
                     COALESCE(rc.name, %(default_currency)s) AS currency_name,
                     s.gift_type || '|' || COALESCE(s.sponsorship_gift_type, '') AS metadata,
-                    s.create_date,
+                    s.create_date AS timeline_date,
                     CASE
                         WHEN s.sponsorship_gift_type = 'Birthday' THEN %(title_gift_bday)s
                         WHEN s.sponsorship_gift_type = 'General' THEN %(title_gift_general)s
@@ -189,7 +190,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     COALESCE(p.gender, '') AS metadata,
-                    p.create_date,
+                    p.create_date AS timeline_date,
                     %(title_child_picture)s AS title,
                     p.child_id AS child_id
                 FROM compassion_child_pictures p
@@ -203,7 +204,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     '' AS metadata,
-                    rc.start_date::timestamp AS create_date,
+                    rc.start_date::timestamp AS timeline_date,
                     %(title_start_sponsorship)s AS title,
                     rc.child_id AS child_id
                 FROM recurring_contract rc
@@ -213,7 +214,7 @@ class MyCompassionChildrenController(WebsiteChild):
                   AND rc.start_date IS NOT NULL
 
             ) AS timeline
-            ORDER BY create_date DESC
+            ORDER BY timeline_date DESC 
             LIMIT %(limit)s OFFSET %(offset)s
         """
 

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -162,7 +162,12 @@ class MyCompassionChildrenController(WebsiteChild):
                 FROM correspondence c
                 WHERE c.child_id = %(child_id)s
                   AND c.partner_id = ANY(%(partner_ids)s)
-                  AND c.state = 'Published to Global Partner'
+                  -- Updated Filtering Logic
+                  AND (
+                      (c.state = 'Published to Global Partner' AND c.direction = 'Beneficiary To Supporter')
+                      OR
+                      (c.state = 'Printed and sent to ICP' AND c.direction = 'Supporter To Beneficiary')
+                  )
 
                 UNION ALL
 
@@ -221,7 +226,6 @@ class MyCompassionChildrenController(WebsiteChild):
             ORDER BY event_date DESC
             LIMIT %(limit)s OFFSET %(offset)s
         """
-
         params = {
             "child_id": child_id,
             "partner_ids": partner_ids,

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -154,7 +154,7 @@ class MyCompassionChildrenController(WebsiteChild):
                             THEN %(title_corr_wrote)s
                         WHEN c.state = 'Printed and sent to ICP'
                             THEN %(title_corr_received)s
-                        WHEN c.state = 'Field Office translation queue' OR c.state = 'Global Partner translation queue'
+                        WHEN c.state IN ('Field Office translation queue', 'Global Partner translation queue')
                             THEN %(title_corr_translating)s
                         ELSE %(title_corr_processing)s
                     END AS title,

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -148,11 +148,15 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     c.direction AS metadata,
-                    c.create_date,
+                    c.status_date AS event_date,
                     CASE
-                        WHEN c.direction = 'Beneficiary To Supporter'
-                        THEN %(title_corr_wrote)s
-                        ELSE %(title_corr_received)s
+                        WHEN c.state = 'Published to Global Partner'
+                            THEN %(title_corr_wrote)s
+                        WHEN c.state = 'Printed and sent to ICP'
+                            THEN %(title_corr_received)s
+                        WHEN c.state = 'Field Office translation queue' OR c.state = 'Global Partner translation queue'
+                            THEN %(title_corr_translating)s
+                        ELSE %(title_corr_processing)s
                     END AS title,
                     c.child_id AS child_id
                 FROM correspondence c
@@ -167,7 +171,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     s.amount::text AS amount,
                     COALESCE(rc.name, %(default_currency)s) AS currency_name,
                     s.gift_type || '|' || COALESCE(s.sponsorship_gift_type, '') AS metadata,
-                    s.create_date,
+                    s.create_date as event_date,
                     CASE
                         WHEN s.sponsorship_gift_type = 'Birthday' THEN %(title_gift_bday)s
                         WHEN s.sponsorship_gift_type = 'General' THEN %(title_gift_general)s
@@ -189,7 +193,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     COALESCE(p.gender, '') AS metadata,
-                    p.create_date,
+                    p.create_date as event_date,
                     %(title_child_picture)s AS title,
                     p.child_id AS child_id
                 FROM compassion_child_pictures p
@@ -203,7 +207,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     '' AS metadata,
-                    rc.start_date::timestamp AS create_date,
+                    rc.start_date::timestamp AS event_date,
                     %(title_start_sponsorship)s AS title,
                     rc.child_id AS child_id
                 FROM recurring_contract rc
@@ -213,7 +217,7 @@ class MyCompassionChildrenController(WebsiteChild):
                   AND rc.start_date IS NOT NULL
 
             ) AS timeline
-            ORDER BY create_date DESC
+            ORDER BY event_date DESC
             LIMIT %(limit)s OFFSET %(offset)s
         """
 
@@ -223,6 +227,8 @@ class MyCompassionChildrenController(WebsiteChild):
             "default_currency": request.env.user.currency_id.name,
             "title_corr_wrote": _("Wrote you a letter"),
             "title_corr_received": _("Received your letter"),
+            "title_corr_translating": _("Translating letter"),
+            "title_corr_processing": _("Processing letter"),
             "title_gift_bday": _("Birthday gift"),
             "title_gift_general": _("General gift"),
             "title_gift_grad": _("Graduation/Final gift"),

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -171,7 +171,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     s.amount::text AS amount,
                     COALESCE(rc.name, %(default_currency)s) AS currency_name,
                     s.gift_type || '|' || COALESCE(s.sponsorship_gift_type, '') AS metadata,
-                    s.create_date as event_date,
+                    s.create_date AS event_date,
                     CASE
                         WHEN s.sponsorship_gift_type = 'Birthday' THEN %(title_gift_bday)s
                         WHEN s.sponsorship_gift_type = 'General' THEN %(title_gift_general)s
@@ -193,7 +193,7 @@ class MyCompassionChildrenController(WebsiteChild):
                     '' AS amount,
                     '' AS currency_name,
                     COALESCE(p.gender, '') AS metadata,
-                    p.create_date as event_date,
+                    p.create_date AS event_date,
                     %(title_child_picture)s AS title,
                     p.child_id AS child_id
                 FROM compassion_child_pictures p

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -162,6 +162,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 FROM correspondence c
                 WHERE c.child_id = %(child_id)s
                   AND c.partner_id = ANY(%(partner_ids)s)
+                  AND c.state = 'Published to Global Partner'
 
                 UNION ALL
 

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -166,7 +166,7 @@ class MyCompassionChildrenController(WebsiteChild):
                   AND (
                       (c.state = 'Published to Global Partner' AND c.direction = 'Beneficiary To Supporter')
                       OR
-                      (c.state = 'Printed and sent to ICP' AND c.direction = 'Supporter To Beneficiary')
+                      (c.state NOT IN ('Exception', 'Quality check unsuccessful') AND c.direction = 'Supporter To Beneficiary')
                   )
 
                 UNION ALL

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -67,12 +67,18 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         # Build the domain of the filtering of the letters
         filter_domain = [
             ("partner_id", "=", partner.id),
-            ("state", "=", "Published to Global Partner"),
             (
                 "child_id",
                 "in",
                 children_sponsored_by_partner.filtered("can_i_write_letter").ids,
             ),
+            "|",
+            "&",
+            # Only show B->S letters that are published.
+            ("direction", "=", "Beneficiary To Supporter"),
+            ("state", "=", "Published to Global Partner"),
+            # Whatever the state of the letters S -> B is, just show them.
+            ("direction", "=", "Supporter To Beneficiary"),
         ]
 
         if child:

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -89,21 +89,8 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             except AccessError:
                 child = None
 
-        filter_domain += [
-            "|",
-            # If B->S: Check 'sent_date'
-            "&",
-            "&",
-            ("direction", "=", "Beneficiary To Supporter"),
-            ("sent_date", ">=", from_date),
-            ("sent_date", "<=", to_date),
-            # If S->B: Check 'status_date'
-            "&",
-            "&",
-            ("direction", "=", "Supporter To Beneficiary"),
-            ("status_date", ">=", from_date),
-            ("status_date", "<=", to_date),
-        ]
+        filter_domain.append(("status_date", ">=", from_date))
+        filter_domain.append(("status_date", "<=", to_date))
 
         if unread_filter == "true":
             filter_domain.append(("email_read", "=", False))

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -92,13 +92,14 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         filter_domain += [
             "|",
             # If B->S: Check 'sent_date'
-            "&", "&",
+            "&",
+            "&",
             ("direction", "=", "Beneficiary To Supporter"),
             ("sent_date", ">=", from_date),
             ("sent_date", "<=", to_date),
-
             # If S->B: Check 'status_date'
-            "&", "&",
+            "&",
+            "&",
             ("direction", "=", "Supporter To Beneficiary"),
             ("status_date", ">=", from_date),
             ("status_date", "<=", to_date),

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -119,7 +119,7 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             filter_domain.append(("direction", "=", letter_type))
             nr_filters_applied += 1
 
-        order = "sent_date DESC" if sort_order == "newest" else "sent_date ASC"
+        order = "status_date DESC" if sort_order == "newest" else "status_date ASC"
 
         if sort_order == "oldest":
             nr_filters_applied += 1

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -89,8 +89,20 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             except AccessError:
                 child = None
 
-        filter_domain.append(("sent_date", ">=", from_date))
-        filter_domain.append(("sent_date", "<=", to_date))
+        filter_domain += [
+            "|",
+            # If B->S: Check 'sent_date'
+            "&", "&",
+            ("direction", "=", "Beneficiary To Supporter"),
+            ("sent_date", ">=", from_date),
+            ("sent_date", "<=", to_date),
+
+            # If S->B: Check 'status_date'
+            "&", "&",
+            ("direction", "=", "Supporter To Beneficiary"),
+            ("status_date", ">=", from_date),
+            ("status_date", "<=", to_date),
+        ]
 
         if unread_filter == "true":
             filter_domain.append(("email_read", "=", False))

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -67,6 +67,7 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
         # Build the domain of the filtering of the letters
         filter_domain = [
             ("partner_id", "=", partner.id),
+            ("state", "=", "Published to Global Partner"),
             (
                 "child_id",
                 "in",
@@ -82,8 +83,8 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             except AccessError:
                 child = None
 
-        filter_domain.append(("create_date", ">=", from_date))
-        filter_domain.append(("create_date", "<=", to_date))
+        filter_domain.append(("sent_date", ">=", from_date))
+        filter_domain.append(("sent_date", "<=", to_date))
 
         if unread_filter == "true":
             filter_domain.append(("email_read", "=", False))
@@ -100,7 +101,7 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             filter_domain.append(("direction", "=", letter_type))
             nr_filters_applied += 1
 
-        order = "create_date DESC" if sort_order == "newest" else "create_date ASC"
+        order = "sent_date DESC" if sort_order == "newest" else "sent_date ASC"
 
         if sort_order == "oldest":
             nr_filters_applied += 1

--- a/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
+++ b/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
@@ -16,7 +16,7 @@
         - model (string): the model of the item (e.g., 'sponsorship_gift', 'correspondence').
         - title (string): title of the item.
         - content (string): content or description of the item.
-        - create_date (string): date when the item was created.
+        - event_date (string): date when the item was last updated.
         - pageable (object): pagination object if applicable, used for loading more items.
         - additional fields as needed based on the model
 -->
@@ -52,7 +52,7 @@
                         </t>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </div>
@@ -87,7 +87,7 @@
                         </t>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </a>
@@ -112,7 +112,7 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </a>
@@ -129,7 +129,7 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </div>

--- a/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
+++ b/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
@@ -16,7 +16,7 @@
         - model (string): the model of the item (e.g., 'sponsorship_gift', 'correspondence').
         - title (string): title of the item.
         - content (string): content or description of the item.
-        - create_date (string): date when the item was created.
+        - timeline_date (string): date of the object in the timeline.
         - pageable (object): pagination object if applicable, used for loading more items.
         - additional fields as needed based on the model
 -->
@@ -52,7 +52,7 @@
                         </t>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['timeline_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </div>
@@ -87,7 +87,7 @@
                         </t>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['timeline_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </a>
@@ -112,7 +112,7 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['timeline_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </a>
@@ -129,7 +129,7 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="cd-timeline__date">
-                                <t t-esc="item['create_date']" t-options='{"widget": "date"}' />
+                                <t t-esc="item['timeline_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
                     </div>


### PR DESCRIPTION
## Note
This PR depends on the following PR : https://github.com/CompassionCH/compassion-website/pull/273

## Summary 
This PR solves the following problems: 
1) Letters Beneficiary -> Supporter were displayed although they were not yet published.
2) The ordering of the letters took into account the create_date, which is wrong and should take into account the status date. 
