### PR TITLE
T2953 Mother & child sponsorship display issue

### DIFF
--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -124,57 +124,52 @@
             </div>
         </div>
     </template>
-
     <template id="SponsorshipDonationItem" name="Sponsorship Donation Item">
-
         <t t-set="label_see_profile">See profile</t>
-
-        <t t-if = "sponsorship.type == 'CSP'">
-
-
-        <t t-set="secondary_buttons_data" t-value="[
+        <t t-if="sponsorship.type == 'CSP'">
+            <t
+                t-set="secondary_buttons_data"
+                t-value="[
             {
                 'icon': 'download01',
                 'color': 'low-blue',
                 'action': 'link',
                 'href': '/my/download/csp_bvr?csp_id=' + str(sponsorship.id),
             }
-        ]"/>
+        ]"
+            />
         </t>
-
-
-
-        <t t-else = "">
-        <t t-set="primary_button_data" t-value="{
+        <t t-else="">
+            <t
+                t-set="primary_button_data"
+                t-value="{
             'label': label_see_profile or 'See Pcxcxrofile',
             'pictogram': 'child-sponsorship',
             'action': 'link',
             'href': '/my2/children/' + str(sponsorship.child_id.id),
             'color': 'low-blue'
-        }"/>
-
-        <t t-set="secondary_buttons_data" t-value="[
+        }"
+            />
+            <t
+                t-set="secondary_buttons_data"
+                t-value="[
             {
                 'icon': 'download01',
                 'color': 'low-blue',
                 'action': 'link',
                 'href': '/my/download/gift_bvr?child_id=' + str(sponsorship.child_id.id),
             }
-        ]"/>
+        ]"
+            />
         </t>
-
-
-
         <t t-call="my_compassion.DonationItemComponent">
             <t t-set="name" t-value="sponsorship.child_id.preferred_name" />
             <t t-set="image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
             <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />
             <t t-set="price" t-value="sponsorship.total_amount" />
-<!--            <t t-set="currency_name" t-value="sponsorship.currency_id.name" />-->
-
+            <!--            <t t-set="currency_name" t-value="sponsorship.currency_id.name" />-->
             <t t-set="primary_button" t-value="primary_button_data" />
             <t t-set="secondary_buttons" t-value="secondary_buttons_data" />
-
             <t t-set="monthly_noabbr" t-value="True" />
             <t t-set="bg_color" t-value="'light-blue'" />
             <t t-set="accent_color" t-value="'low-blue'" />

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -124,4 +124,62 @@
             </div>
         </div>
     </template>
+
+    <template id="SponsorshipDonationItem" name="Sponsorship Donation Item">
+
+        <t t-set="label_see_profile">See profile</t>
+
+        <t t-if = "sponsorship.type == 'CSP'">
+
+
+        <t t-set="secondary_buttons_data" t-value="[
+            {
+                'icon': 'download01',
+                'color': 'low-blue',
+                'action': 'link',
+                'href': '/my/download/csp_bvr?csp_id=' + str(sponsorship.id),
+            }
+        ]"/>
+        </t>
+
+
+
+        <t t-else = "">
+        <t t-set="primary_button_data" t-value="{
+            'label': label_see_profile or 'See Pcxcxrofile',
+            'pictogram': 'child-sponsorship',
+            'action': 'link',
+            'href': '/my2/children/' + str(sponsorship.child_id.id),
+            'color': 'low-blue'
+        }"/>
+
+        <t t-set="secondary_buttons_data" t-value="[
+            {
+                'icon': 'download01',
+                'color': 'low-blue',
+                'action': 'link',
+                'href': '/my/download/gift_bvr?child_id=' + str(sponsorship.child_id.id),
+            }
+        ]"/>
+        </t>
+
+
+
+        <t t-call="my_compassion.DonationItemComponent">
+            <t t-set="name" t-value="sponsorship.child_id.preferred_name" />
+            <t t-set="image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
+            <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />
+            <t t-set="price" t-value="sponsorship.total_amount" />
+<!--            <t t-set="currency_name" t-value="sponsorship.currency_id.name" />-->
+
+            <t t-set="primary_button" t-value="primary_button_data" />
+            <t t-set="secondary_buttons" t-value="secondary_buttons_data" />
+
+            <t t-set="monthly_noabbr" t-value="True" />
+            <t t-set="bg_color" t-value="'light-blue'" />
+            <t t-set="accent_color" t-value="'low-blue'" />
+            <t t-set="title_color" t-value="'low-blue'" />
+            <t t-set="price_color" t-value="'low-blue'" />
+        </t>
+    </template>
 </odoo>

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -127,16 +127,11 @@
     <template id="SponsorshipDonationItem" name="Sponsorship Donation Item">
         <t t-set="label_see_profile">See profile</t>
         <t t-if="sponsorship.type == 'CSP'">
-
-
             <t t-set="templates" t-value="sponsorship.contract_line_ids.product_id.product_tmpl_id" />
             <t t-set="csp_my_compassion_name" t-value="templates.mapped('my_compassion_name')[0]" />
             <t t-set="csp_thanks_name" t-value="templates.mapped('thanks_name')[0]" />
-            <t t-set="displayed_title" t-value="csp_my_compassion_name if csp_my_compassion_name else csp_thanks_name" />
-
-
-
-
+            <t t-set="csp_default_name">Compassion survival program"</t>
+            <t t-set="displayed_title" t-value="csp_my_compassion_name or csp_thanks_name or csp_default_name" />
             <t
                 t-set="secondary_buttons_data"
                 t-value="[

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -44,10 +44,7 @@
         />
         <div t-attf-class="action-button #{button_top_class}" t-att-onclick="onclick">
             <i t-if="button.get('icon')" t-attf-class="tiny-text icon-#{button.get('icon')} text-#{color}" />
-            <i
-                t-if="button.get('pictogram')"
-                t-attf-class="tiny-text pictogram-#{button.get('pictogram')} text-#{color}"
-            />
+            <i t-if="button.get('pictogram')" t-attf-class="tiny-text #{button.get('pictogram')} text-#{color}" />
             <span t-if="button.get('label')" t-attf-class="tiny-text bold text-#{color}">
                 <t t-esc="button.get('label')" />
             </span>
@@ -125,22 +122,26 @@
     </template>
     <template id="SponsorshipDonationItem" name="Sponsorship Donation Item">
         <t t-set="label_see_profile">See profile</t>
+        <t t-set="label_see_more">See more</t>
         <t t-if="sponsorship.type == 'CSP'">
             <t t-set="product_template" t-value="sponsorship.contract_line_ids.product_id.product_tmpl_id[0]" />
             <t t-set="csp_my_compassion_name" t-value="product_template.my_compassion_name" />
             <t t-set="csp_thanks_name" t-value="product_template.thanks_name" />
             <t t-set="csp_default_name">Compassion survival program"</t>
             <t t-set="displayed_title" t-value="csp_my_compassion_name or csp_thanks_name or csp_default_name" />
-            <t
-                t-set="primary_button_data"
-                t-value="{
-            'label': label_see_profile,
-            'pictogram': product_template.my_compassion_pictogram.class_name or 'gift-donation-general',
+            <t t-if="product_template.is_published">
+                <t t-set="displayed_image" t-value="website.image_url(product_template, 'my_compassion_image')" />
+                <t
+                    t-set="primary_button_data"
+                    t-value="{
+            'label': label_see_more,
+            'pictogram': product_template.my_compassion_pictogram.class_name or 'pictogram-gift-donation-general',
             'action': 'link',
             'href': '/my2/gifts/' + str(product_template.id),
             'color': 'low-blue'
         }"
-            />
+                />
+            </t>
             <t
                 t-set="secondary_buttons_data"
                 t-value="[
@@ -155,11 +156,12 @@
         </t>
         <t t-else="">
             <t t-set="displayed_title" t-value="sponsorship.child_id.preferred_name" />
+            <t t-set="displayed_image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
             <t
                 t-set="primary_button_data"
                 t-value="{
             'label': label_see_profile,
-            'pictogram': 'child-sponsorship',
+            'pictogram': 'pictogram-child-sponsorship',
             'action': 'link',
             'href': '/my2/children/' + str(sponsorship.child_id.id),
             'color': 'low-blue'
@@ -179,7 +181,7 @@
         </t>
         <t t-call="my_compassion.DonationItemComponent">
             <t t-set="name" t-value="displayed_title" />
-            <t t-set="image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
+            <t t-set="image" t-value="displayed_image" />
             <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />
             <t t-set="price" t-value="sponsorship.total_amount" />
             <!--            <t t-set="currency_name" t-value="sponsorship.currency_id.name" />-->

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <!--
     Component: Donation Item
 
@@ -127,11 +126,21 @@
     <template id="SponsorshipDonationItem" name="Sponsorship Donation Item">
         <t t-set="label_see_profile">See profile</t>
         <t t-if="sponsorship.type == 'CSP'">
-            <t t-set="templates" t-value="sponsorship.contract_line_ids.product_id.product_tmpl_id" />
-            <t t-set="csp_my_compassion_name" t-value="templates.mapped('my_compassion_name')[0]" />
-            <t t-set="csp_thanks_name" t-value="templates.mapped('thanks_name')[0]" />
+            <t t-set="product_template" t-value="sponsorship.contract_line_ids.product_id.product_tmpl_id[0]" />
+            <t t-set="csp_my_compassion_name" t-value="product_template.my_compassion_name" />
+            <t t-set="csp_thanks_name" t-value="product_template.thanks_name" />
             <t t-set="csp_default_name">Compassion survival program"</t>
             <t t-set="displayed_title" t-value="csp_my_compassion_name or csp_thanks_name or csp_default_name" />
+            <t
+                t-set="primary_button_data"
+                t-value="{
+            'label': label_see_profile,
+            'pictogram': product_template.my_compassion_pictogram.class_name or 'gift-donation-general',
+            'action': 'link',
+            'href': '/my2/gifts/' + str(product_template.id),
+            'color': 'low-blue'
+        }"
+            />
             <t
                 t-set="secondary_buttons_data"
                 t-value="[

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -22,6 +22,7 @@
     - primary_button (dict): Primary button with custom action (see Button).                 [none]
     - recipient (string): Item recipient.                                                    [none]
     - subtext (string): Text under name and recipient.                                       [none]
+    - image_fallback_pictogram : Pictogram to display instead of the image when it's None              [none]
     - title_color (string): Color of the title.                                              [dark-blue]
     - accent_color (string): Color of the left border accent.                                [dark-blue]
     - price_color (string): Color of the price.                                              [dark-blue]
@@ -76,7 +77,7 @@
             t-attf-style="min-width: #{min_width}"
         >
             <div
-                class="thumbnail responsive-lg mr-3 flex-shrink-0 rounded-lg"
+                t-attf-class="thumbnail responsive-lg mr-3 flex-shrink-0 rounded-lg #{not image and image_fallback_pictogram or ''}"
                 t-attf-style="--image_url: url('#{image}');"
             />
             <t t-if="not primary_button" t-raw="small_thumbnail_content" />
@@ -129,6 +130,10 @@
             <t t-set="csp_thanks_name" t-value="product_template.thanks_name" />
             <t t-set="csp_default_name">Compassion survival program"</t>
             <t t-set="displayed_title" t-value="csp_my_compassion_name or csp_thanks_name or csp_default_name" />
+            <t
+                t-set="image_fallback_pictogram"
+                t-value="product_template.my_compassion_pictogram.class_name or 'pictogram-gift-donation-general'"
+            />
             <t t-if="product_template.is_published">
                 <t t-set="displayed_image" t-value="website.image_url(product_template, 'my_compassion_image')" />
                 <t
@@ -180,6 +185,7 @@
             />
         </t>
         <t t-call="my_compassion.DonationItemComponent">
+            <t t-set="image_fallback_pictogram" t-value="image_fallback_pictogram" />
             <t t-set="name" t-value="displayed_title" />
             <t t-set="image" t-value="displayed_image" />
             <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -22,7 +22,7 @@
     - primary_button (dict): Primary button with custom action (see Button).                 [none]
     - recipient (string): Item recipient.                                                    [none]
     - subtext (string): Text under name and recipient.                                       [none]
-    - image_fallback_pictogram : Pictogram to display instead of the image when it's None              [none]
+    - image_fallback_pictogram : Pictogram to display instead of the image when it's None    [none]
     - title_color (string): Color of the title.                                              [dark-blue]
     - accent_color (string): Color of the left border accent.                                [dark-blue]
     - price_color (string): Color of the price.                                              [dark-blue]
@@ -190,7 +190,6 @@
             <t t-set="image" t-value="displayed_image" />
             <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />
             <t t-set="price" t-value="sponsorship.total_amount" />
-            <!--            <t t-set="currency_name" t-value="sponsorship.currency_id.name" />-->
             <t t-set="primary_button" t-value="primary_button_data" />
             <t t-set="secondary_buttons" t-value="secondary_buttons_data" />
             <t t-set="monthly_noabbr" t-value="True" />

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -127,6 +127,16 @@
     <template id="SponsorshipDonationItem" name="Sponsorship Donation Item">
         <t t-set="label_see_profile">See profile</t>
         <t t-if="sponsorship.type == 'CSP'">
+
+
+            <t t-set="templates" t-value="sponsorship.contract_line_ids.product_id.product_tmpl_id" />
+            <t t-set="csp_my_compassion_name" t-value="templates.mapped('my_compassion_name')[0]" />
+            <t t-set="csp_thanks_name" t-value="templates.mapped('thanks_name')[0]" />
+            <t t-set="displayed_title" t-value="csp_my_compassion_name if csp_my_compassion_name else csp_thanks_name" />
+
+
+
+
             <t
                 t-set="secondary_buttons_data"
                 t-value="[
@@ -140,10 +150,11 @@
             />
         </t>
         <t t-else="">
+            <t t-set="displayed_title" t-value="sponsorship.child_id.preferred_name" />
             <t
                 t-set="primary_button_data"
                 t-value="{
-            'label': label_see_profile or 'See Pcxcxrofile',
+            'label': label_see_profile,
             'pictogram': 'child-sponsorship',
             'action': 'link',
             'href': '/my2/children/' + str(sponsorship.child_id.id),
@@ -163,7 +174,7 @@
             />
         </t>
         <t t-call="my_compassion.DonationItemComponent">
-            <t t-set="name" t-value="sponsorship.child_id.preferred_name" />
+            <t t-set="name" t-value="displayed_title" />
             <t t-set="image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
             <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />
             <t t-set="price" t-value="sponsorship.total_amount" />

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -68,7 +68,7 @@
         <!--Small image on the card  -->
         <t t-set="small_thumbnail_content">
             <div
-                class="thumbnail responsive-sm mr-3 flex-shrink-0 rounded-lg"
+                t-attf-class="thumbnail responsive-sm mr-3 flex-shrink-0 rounded-lg #{not image and image_fallback_pictogram or ''}"
                 t-attf-style="--image_url: url('#{image}');"
             />
         </t>
@@ -125,42 +125,44 @@
         <t t-set="label_see_profile">See profile</t>
         <t t-set="label_see_more">See more</t>
         <t t-if="sponsorship.type == 'CSP'">
-            <t t-set="product_template" t-value="sponsorship.contract_line_ids.product_id.product_tmpl_id[0]" />
-            <t t-set="csp_my_compassion_name" t-value="product_template.my_compassion_name" />
-            <t t-set="csp_thanks_name" t-value="product_template.thanks_name" />
-            <t t-set="csp_default_name">Compassion survival program"</t>
-            <t t-set="displayed_title" t-value="csp_my_compassion_name or csp_thanks_name or csp_default_name" />
-            <t
-                t-set="image_fallback_pictogram"
-                t-value="product_template.my_compassion_pictogram.class_name or 'pictogram-gift-donation-general'"
-            />
-            <t t-if="product_template.is_published">
-                <t t-set="displayed_image" t-value="website.image_url(product_template, 'my_compassion_image')" />
+            <t t-set="product_template" t-value="sponsorship.contract_line_ids[:1].product_id.product_tmpl_id" />
+            <t t-if="product_template">
+                <t t-set="csp_my_compassion_name" t-value="product_template.my_compassion_name" />
+                <t t-set="csp_thanks_name" t-value="product_template.thanks_name" />
+                <t t-set="csp_default_name">Compassion survival program</t>
+                <t t-set="displayed_title" t-value="csp_my_compassion_name or csp_thanks_name or csp_default_name" />
                 <t
-                    t-set="primary_button_data"
-                    t-value="{
-            'label': label_see_more,
-            'pictogram': product_template.my_compassion_pictogram.class_name or 'pictogram-gift-donation-general',
-            'action': 'link',
-            'href': '/my2/gifts/' + str(product_template.id),
-            'color': 'low-blue'
-        }"
+                    t-set="image_fallback_pictogram"
+                    t-value="product_template.my_compassion_pictogram.class_name or 'pictogram-gift-donation-general'"
+                />
+                <t t-if="product_template.is_published">
+                    <t t-set="displayed_image" t-value="website.image_url(product_template, 'my_compassion_image')" />
+                    <t
+                        t-set="primary_button_data"
+                        t-value="{
+                'label': label_see_more,
+                'pictogram': product_template.my_compassion_pictogram.class_name or 'pictogram-gift-donation-general',
+                'action': 'link',
+                'href': '/my2/gifts/' + str(product_template.id),
+                'color': 'low-blue'
+            }"
+                    />
+                </t>
+                <t
+                    t-set="secondary_buttons_data"
+                    t-value="[
+                {
+                    'icon': 'download01',
+                    'color': 'low-blue',
+                    'action': 'link',
+                    'href': '/my/download/csp_bvr?csp_id=' + str(sponsorship.id),
+                }
+            ]"
                 />
             </t>
-            <t
-                t-set="secondary_buttons_data"
-                t-value="[
-            {
-                'icon': 'download01',
-                'color': 'low-blue',
-                'action': 'link',
-                'href': '/my/download/csp_bvr?csp_id=' + str(sponsorship.id),
-            }
-        ]"
-            />
         </t>
         <t t-else="">
-            <t t-set="image_fallback_pictogram" t-value="'pictogram-child-sponsorship'"/>
+            <t t-set="image_fallback_pictogram" t-value="'pictogram-child-sponsorship'" />
             <t t-set="displayed_title" t-value="sponsorship.child_id.preferred_name" />
             <t t-set="displayed_image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
             <t

--- a/my_compassion/templates/components/my2_donation_item.xml
+++ b/my_compassion/templates/components/my2_donation_item.xml
@@ -160,6 +160,7 @@
             />
         </t>
         <t t-else="">
+            <t t-set="image_fallback_pictogram" t-value="'pictogram-child-sponsorship'"/>
             <t t-set="displayed_title" t-value="sponsorship.child_id.preferred_name" />
             <t t-set="displayed_image" t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait" />
             <t

--- a/my_compassion/templates/pages/my2_donations.xml
+++ b/my_compassion/templates/pages/my2_donations.xml
@@ -111,8 +111,8 @@ Page: My Compassion 2 Donations Page
                                 <t t-if="sponsorship">
                                     <div class="mb-4">
                                         <t t-call="my_compassion.SponsorshipDonationItem">
-                                            <t t-set="sponsorship" t-value="sponsorship"/>
-                                            </t>
+                                            <t t-set="sponsorship" t-value="sponsorship" />
+                                        </t>
                                     </div>
                                 </t>
                             </t>

--- a/my_compassion/templates/pages/my2_donations.xml
+++ b/my_compassion/templates/pages/my2_donations.xml
@@ -110,44 +110,9 @@ Page: My Compassion 2 Donations Page
                             <t t-foreach="active_sponsorships" t-as="sponsorship">
                                 <t t-if="sponsorship">
                                     <div class="mb-4">
-                                        <t t-set="label_see_profile">See profile</t>
-                                        <t
-                                            t-set="primary_button_data"
-                                            t-value="{
-                        'label': label_see_profile,
-                        'pictogram': 'child-sponsorship',
-                        'action': 'link',
-                        'href': '/my2/children/' + str(sponsorship.child_id.id),
-                        'color': 'low-blue'
-                    }"
-                                        />
-                                        <t
-                                            t-set="secondary_buttons_data"
-                                            t-value="[
-                        {
-                            'icon': 'download01',
-                            'color': 'low-blue',
-                            'action': 'link',
-                            'href': '/my/download/gift_bvr?child_id=' + str(sponsorship.child_id.id),
-                        }
-                    ]"
-                                        />
-                                        <t t-call="my_compassion.DonationItemComponent">
-                                            <t t-set="name" t-value="sponsorship.child_id.preferred_name" />
-                                            <t
-                                                t-set="image"
-                                                t-valuef="/web/image/compassion.child/#{sponsorship.child_id.id}/portrait"
-                                            />
-                                            <t t-set="subtext" t-value="sponsorship.payment_mode_id.display_name" />
-                                            <t t-set="price" t-value="sponsorship.total_amount" />
-                                            <t t-set="primary_button" t-value="primary_button_data" />
-                                            <t t-set="monthly_noabbr" t-value="True" />
-                                            <t t-set="secondary_buttons" t-value="secondary_buttons_data" />
-                                            <t t-set="bg_color" t-value="'light-blue'" />
-                                            <t t-set="accent_color" t-value="'low-blue'" />
-                                            <t t-set="title_color" t-value="'low-blue'" />
-                                            <t t-set="price_color" t-value="'low-blue'" />
-                                        </t>
+                                        <t t-call="my_compassion.SponsorshipDonationItem">
+                                            <t t-set="sponsorship" t-value="sponsorship"/>
+                                            </t>
                                     </div>
                                 </t>
                             </t>


### PR DESCRIPTION
## Note : 
This PR is linked to this one : https://github.com/CompassionCH/compassion-switzerland/pull/1743

## Problem description 

In the `/my2/donations` the sponsorship component didn't handle well sponsorship that do not involve children (namely CSP). 
This results in errors when loading the Sponsorship fields (name, pictures, pictogram) and the href to the child Profile.
An error also arise when the user tries to download the bvr of the CSP. 
##  How to reproduce the bug 

- Connect to  MC2 with user having id = 2308. 
- Go to the /donations page and see that the 2nd row is broken 
<img width="886" height="140" alt="image" src="https://github.com/user-attachments/assets/a3541991-2a7a-40c4-ade2-6205e2ab0112" />


## Solution 
This PR mostly refactor the existing code to adapt it to CSP sponsorship. 
1) Show the product my_compassion_name of the CSP (thanks_name if absent, a default text in the worst case).
2) Show the my_compassion_image of the CSP (the csp pictogram if absent, a default pictogram in the worst case)
3) Add a **See more** button that links to the presentation page of the CSP product (hidden if absent)
4) Adapt the generation of the BVR for CSP.  

## Pictures 
### CSP product is well filled (pictures, has a mc2 page and proper title)

<img width="786" height="132" alt="Screenshot from 2026-02-04 13-15-17" src="https://github.com/user-attachments/assets/b3aaab56-b532-405f-b9c5-52c1adde3e72" />

### CSP product lacks mc2 page and proper image/pictogram but has compassion_name/thanks_name
<img width="786" height="132" alt="Screenshot from 2026-02-04 13-16-40" src="https://github.com/user-attachments/assets/92545d23-550d-4cfb-959a-125c2e930bf8" />

## Same as previous but without any compassion_name/thanks_name 
<img width="886" height="140" alt="image" src="https://github.com/user-attachments/assets/a6839955-cf6c-461d-8b77-609c2d1693c3" />

