### PR TITLE
[FIX] T2971: Allow dynamic input name for Password widget

### DIFF
--- a/my_compassion/static/src/js/my2_signup_fields.js
+++ b/my_compassion/static/src/js/my2_signup_fields.js
@@ -13,9 +13,12 @@ document.addEventListener("DOMContentLoaded", function (event) {
             start: function () {
                 // Create password elements
 
-                for (var $password of this.$(".password")) {
-                    var password = new publicWidget.registry.Password(this);
-                    password.replace($password);
+                for (var passwordElement of this.$(".password")) {
+                    var $passwordElement = $(passwordElement);
+                    var password = new publicWidget.registry.Password(this, {
+                        inputName: $passwordElement.data("name"),
+                    });
+                    password.replace($passwordElement);
                 }
 
                 return this._super.apply(this, arguments);

--- a/my_compassion/templates/pages/my2_login_template.xml
+++ b/my_compassion/templates/pages/my2_login_template.xml
@@ -153,13 +153,13 @@
                 <t t-if="only_passwords" t-call="theme_compassion_2025.FormFieldComponent">
                     <t t-set="top_class" t-value="'mt-2'" />
                     <t t-set="label">Password</t>
-                    <div class="password" />
+                    <div class="password" data-name="password" />
                 </t>
                 <!-- Confirm password -->
                 <t t-if="only_passwords" t-call="theme_compassion_2025.FormFieldComponent">
                     <t t-set="top_class" t-value="'mt-2'" />
                     <t t-set="label">Confirm Password</t>
-                    <div class="password" />
+                    <div class="password" data-name="confirm_password" />
                 </t>
                 <!-- Accept terms & conditions -->
                 <div class="mt-3 d-flex">

--- a/theme_compassion_2025/static/src/js/_password.js
+++ b/theme_compassion_2025/static/src/js/_password.js
@@ -20,6 +20,7 @@ odoo.define("theme_compassion_2025.password", function (require) {
         init: function (parent, options) {
             this._super.apply(this, arguments);
             this.required = (options && options.required) || false;
+            this.inputName = (options && options.inputName) || "password";
         },
 
         /**

--- a/theme_compassion_2025/static/src/xml/Password.xml
+++ b/theme_compassion_2025/static/src/xml/Password.xml
@@ -14,7 +14,7 @@
         <div class="password-container">
             <input
                 type="password"
-                name="password"
+                t-att-name="widget.inputName"
                 class="form-control"
                 t-att-required="widget.required"
                 placeholder="Password"


### PR DESCRIPTION
## Fix: Client-side "Passwords do not match" validation error

### Issue
Users were unable to submit the Signup or Reset Password forms due to a persistent client-side error: **"Passwords do not match; please retype them."** This occurred even when both fields contained identical values.

### Root Cause
The issue was caused by a duplicate `name` attribute in the HTML DOM:
* **Hardcoded Widget:** The `Password` widget hardcoded the input name to `password`.
* **Duplicate Instantiation:** The signup fields template instantiated this widget twice—once for the password and once for the confirmation—resulting in two inputs with `name="password"`.
* **Validation Failure:** Odoo's standard JavaScript validation expects the second field to be named `confirm_password`. Because it could not find an input with that specific name, the equality check failed.

### Solution
The `Password` widget was refactored to support dynamic naming, and the templates were updated to provide the correct identifiers.

#### 1. Updated Widget Logic
Modified `theme_compassion_2025.Password` to accept an `inputName` option, defaulting to `password`.
* **JS:** `theme_compassion_2025/static/src/js/_password.js`
* **XML:** `theme_compassion_2025/static/src/xml/Password.xml`

#### 2. Updated Templates
Added `data-name` attributes to the placeholder `div` elements to specify the desired input name.
* **File:** `my_compassion/templates/pages/my2_login_template.xml`

#### 3. Updated Initialization
The initialization script now reads the `data-name` from the DOM element and passes it to the widget during instantiation.
* **File:** `my_compassion/static/src/js/my2_signup_fields.js`
