### PR TITLE
T2901 'subreject' ended sponsorships shown upon my sponsorships page

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -309,8 +309,9 @@ class MyCompassionChildrenController(WebsiteChild):
                 ),
                 "ended_sponsorships": sponsorships.filtered(
                     lambda s: s.state == "terminated"
-                              and s.sds_state != "sub_waiting"
-                            and s.end_reason_id.name not in ["Subreject","Mistake from our staff"]
+                    and s.sds_state != "sub_waiting"
+                    and s.end_reason_id.name
+                    not in ["Subreject", "Mistake from our staff"]
                 ),
                 "latest_correspondences_by_child_id": latest_corr_by_child,
                 "breadcrumbs": breadcrumbs,

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -308,7 +308,9 @@ class MyCompassionChildrenController(WebsiteChild):
                     lambda s: s.state != "terminated" or s.sds_state == "sub_waiting"
                 ),
                 "ended_sponsorships": sponsorships.filtered(
-                    lambda s: s.state == "terminated" and s.sds_state != "sub_waiting"
+                    lambda s: s.state == "terminated"
+                              and s.sds_state != "sub_waiting"
+                            and s.end_reason_id.name not in ["Subreject","Mistake from our staff"]
                 ),
                 "latest_correspondences_by_child_id": latest_corr_by_child,
                 "breadcrumbs": breadcrumbs,


### PR DESCRIPTION
## Summary 

This PR prevent sponsors from seeing the child they ended the sponsorship because of an subreject or a staff mistake reason. 

## How to test : 
The child with ID 8951 is currently sponsored by partnerA(14515) but was before suggested to partnerB(10745) and then cancelled. 
The partnerB currently see the child in the sponsorships page although they rejected it.