### PR TITLE
[T3011] FIX: dashboard page UI improvements

### DIFF
--- a/my_compassion/static/src/css/my2_dashboard.css
+++ b/my_compassion/static/src/css/my2_dashboard.css
@@ -18,10 +18,17 @@
 
 .dashboard-banner h1 {
     font-family: "NeighbourSans Medium";
+    font-size: 2rem;
 }
 
 .dashboard-grid button,
 .dashboard-grid a {
     margin-top: 1.5rem;
     width: 100%;
+}
+
+@media screen and (max-width: 639px) {
+    .grid-item-container {
+        min-width: min(100%, 300px);
+    }
 }

--- a/my_compassion/templates/pages/my2_dashboard.xml
+++ b/my_compassion/templates/pages/my2_dashboard.xml
@@ -16,7 +16,7 @@ Page: My Compassion 2 Dashboard Page
 <odoo>
     <!-- DASHBOARD GRID ITEM -->
     <template id="DashboardGridItem" name="Dashboard grid item">
-        <div class="col-sm my-3 flex-grow-0">
+        <div class="col-sm my-3 flex-grow-0 grid-item-container">
             <t t-raw="0" />
         </div>
     </template>
@@ -86,10 +86,8 @@ Page: My Compassion 2 Dashboard Page
                         <t t-set="variant" t-value="'default'" />
                         <t t-set="variation" t-value="'hollow'" />
                         <t t-set="label">A new letter has arrived!</t>
-                        <t t-set="icon" t-value="'pictogram-child-focused'" />
-                        <t t-set="color" t-value="'low-green'" />
-                        <t t-set="icon_color" t-value="'low-green'" />
-                        <t t-set="text_color" t-value="'low-green'" />
+                        <t t-set="color" t-value="'low-blue'" />
+                        <t t-set="text_color" t-value="'low-blue'" />
                         <t
                             t-set="href"
                             t-value="'/my2/children/letters?year_to=2025&amp;month_from=1&amp;month_to=12&amp;sort=newest&amp;unread=true&amp;page=1'"
@@ -101,9 +99,7 @@ Page: My Compassion 2 Dashboard Page
                         <t t-set="variant" t-value="'default'" />
                         <t t-set="variation" t-value="'filled'" />
                         <t t-set="label">Write to Your sponsored child</t>
-                        <t t-set="icon" t-value="'pictogram-letter-writing'" />
                         <t t-set="color" t-value="'core-blue'" />
-                        <t t-set="icon_color" t-value="'low-yellow'" />
                         <t t-set="text_color" t-value="'pure-white'" />
                         <t t-set="href" t-value="'/my2/children/letters/new'" />
                     </t>
@@ -115,9 +111,7 @@ Page: My Compassion 2 Dashboard Page
                     <t t-set="variant" t-value="'default'" />
                     <t t-set="variation" t-value="'filled'" />
                     <t t-set="label">See my terminated sponsorships</t>
-                    <t t-set="icon" t-value="'pictogram-child-focused'" />
                     <t t-set="color" t-value="'core-blue'" />
-                    <t t-set="icon_color" t-value="'low-yellow'" />
                     <t t-set="text_color" t-value="'pure-white'" />
                     <t t-set="href" t-value="'/my2/children'" />
                 </t>
@@ -140,9 +134,7 @@ Page: My Compassion 2 Dashboard Page
                     <t t-set="variant" t-value="'default'" />
                     <t t-set="variation" t-value="'filled'" />
                     <t t-set="label">My donations</t>
-                    <t t-set="icon" t-value="'pictogram-letter-writing'" />
                     <t t-set="color" t-value="'mid-brown'" />
-                    <t t-set="icon_color" t-value="'pure-white'" />
                     <t t-set="text_color" t-value="'pure-white'" />
                     <t t-set="href" t-value="'/my2/donations'" />
                 </t>
@@ -166,9 +158,7 @@ Page: My Compassion 2 Dashboard Page
                     <t t-set="variant" t-value="'default'" />
                     <t t-set="variation" t-value="'filled'" />
                     <t t-set="label">Translate a letter</t>
-                    <t t-set="icon" t-value="'pictogram-letter-writing'" />
                     <t t-set="color" t-value="'mid-green'" />
-                    <t t-set="icon_color" t-value="'low-green'" />
                     <t t-set="text_color" t-value="'pure-white'" />
                     <t t-set="href" t-value="'https://translate.compassion.ch'" />
                 </t>

--- a/theme_compassion_2025/templates/components/Vignette.xml
+++ b/theme_compassion_2025/templates/components/Vignette.xml
@@ -32,7 +32,7 @@
                         t-attf-class="card-body h-25 py-2 flex-grow-0 d-flex bg-#{bg_color} #{learn_more_text and 'rounded-0' or ''}"
                     >
                         <div t-attf-class="d-flex flex-column justify-content-center flex-grow-1">
-                            <div class="pl-3">
+                            <div class="pl-0 pl-sm-3">
                                 <h3 t-attf-class="card-title m-0 text-#{color}">
                                     <t t-raw="title" />
                                 </h3>


### PR DESCRIPTION
- FIX: Increased the size of the MyCompassion text in the banner.
- FIX: changed min width of card container to better display the vignettes between mobile and desktop view
- FIX: new letter button now uses the same color for the outline as the sponsorship vignette and button (consistency)
- FIX: removed hard distinguishable icons from dashboard buttons
- FIX: Removed padding from vignettes on small screens

## Home Page
### Title
- Increase Welcome to MyCompassion:

Before:
<img width="263" height="149" alt="Welcome to" src="https://github.com/user-attachments/assets/412bdcc0-4d19-48e6-a60d-5264ab3c353c" />
After:
<img width="291" height="168" alt="Welcome to" src="https://github.com/user-attachments/assets/e698db91-702f-4cfb-8756-24cc3a23a59f" />

### Dashboard Cards
- Improved responsivity 
- Changed 'Give' color to white
- Removed hard to distinguish icons from buttons

Before:
<img width="591" height="736" alt="You are sponsoring" src="https://github.com/user-attachments/assets/9d56dee8-0ab7-48d8-b534-61b63c95d990" />
After:
<img width="824" height="963" alt="image" src="https://github.com/user-attachments/assets/842533ee-c237-4cbd-a3ff-05a0042ea5aa" />