### PR TITLE
T3022 sponsorship page

### DIFF
--- a/my_compassion/static/src/css/my2_children_card.css
+++ b/my_compassion/static/src/css/my2_children_card.css
@@ -9,3 +9,12 @@
     object-fit: cover;
     object-position: 50% 0;
 }
+
+.children-card {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.children-card .pending {
+    font-size: 1.2rem;
+}

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -20,7 +20,8 @@
         <t t-set="sponsorship_type" t-value="sponsorship_type or 'standard'" />
         <t t-set="show_status" t-value="not show_status == False" />
         <div class="children-card text-center mb-3 mt-3">
-            <div class="p-4 d-flex flex-column align-items-center bg-high-eggshell">
+            <div class="p-4 d-flex flex-column align-items-center bg-low-eggshell position-relative rounded-pill">
+                <a t-attf-href="/my2/children/{{child.id}}" class="stretched-link" aria-label="Child profile" />
                 <!-- Child Image -->
                 <img
                     class="rounded-circle img-fluid mb-2"
@@ -31,7 +32,7 @@
                 <div class="h2 mb-0">
                     <t t-esc="child.preferred_name" />
                 </div>
-                <div class="small" t-if="sponsorship and sponsorship.state in ('draft', 'waiting', 'mandate')">
+                <div class="pending" t-if="sponsorship and sponsorship.state in ('draft', 'waiting', 'mandate')">
                     <span
                         class="badge bg-low-yellow"
                         title="Your sponsorship is being confirmed and will become active soon"

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -29,7 +29,7 @@ Page: My Compassion 2 Children Page
                 <!-- ACTIVE SPONSORSHIPS CHILDREN-->
                 <div class="container-content d-flex flex-column align-items-center mt-4 mb-5">
                     <div class="w-100 d-flex flex-column">
-                        <div class="row justify-content-center align-items-stretch">
+                        <div class="row justify-content-center align-items-stretch p-0 p-sm-3">
                             <t t-foreach="active_sponsorships" t-as="sponsorship">
                                 <div class="col-12 col-md-6 col-lg-4 mb-3">
                                     <t t-call="my_compassion.my2_children_card_component">

--- a/theme_compassion_2025/static/src/scss/base/_borders.scss
+++ b/theme_compassion_2025/static/src/scss/base/_borders.scss
@@ -31,3 +31,11 @@
 .rounded-5 {
   border-radius: 1rem !important;
 }
+
+.rounded-pill {
+  border-radius: 25px !important;
+}
+
+.padding-pill {
+  padding: 10px 15px !important;
+}


### PR DESCRIPTION
- FIX: centered and changed max width of child cards to 400px to make sure they don't scale in a weird way for example on tablets, or large phones
- FIX: Increased the size of the "pending" indicator
- FIX: Tweaked the bg-color of the card, for better visibility and made the whole card clickable (mobile users will thank us for it)
- FIX: added padding to card container on sm+ screens
- FEAT: added rounded-pill and padding-pill global css classes for consistency

## My Sponsorships page
- Tweaked child card background color
- Applied uniform border radius and padding
- Increased 'Pending activation' like texts size
- Made whole card clickable (important for mobile users)

Before:
<img width="344" height="511" alt="Bimenyimana" src="https://github.com/user-attachments/assets/6c6d2558-e1e9-48b7-a5e5-de456a9cc5ef" />
After:
<img width="474" height="514" alt="Bimenyimana" src="https://github.com/user-attachments/assets/76f50e1c-8ba9-4549-8901-eedeced644f2" />