### PR TITLE
[T3011] FIX: child details page UI improvements

### DIFF
--- a/my_compassion/static/src/css/child_profile_timeline.css
+++ b/my_compassion/static/src/css/child_profile_timeline.css
@@ -90,14 +90,15 @@
     align-items: center;
     -ms-flex-negative: 0;
     flex-shrink: 0;
-    width: 40px;
-    height: 40px;
+    width: 50px;
+    height: 50px;
+    margin-left: -5px;
     border-radius: 50%;
     box-shadow: 0 0 0 4px hsl(0, 0%, 100%), inset 0 2px 0 rgba(0, 0, 0, 0.08), 0 3px 0 4px rgba(0, 0, 0, 0.05);
 }
 .cd-timeline__img .pictogram {
-    width: 45px;
-    height: 45px;
+    width: 55px;
+    height: 55px;
 }
 @media (min-width: 64rem) {
     .cd-timeline__img {
@@ -126,6 +127,11 @@
     padding: 1.25em;
     box-shadow: 0 3px 0 hsl(205, 38%, 89%);
 }
+
+.cd-timeline__content > p.text-muted {
+    margin-bottom: 0;
+}
+
 .cd-timeline__content::before {
     content: "";
     position: absolute;
@@ -164,6 +170,11 @@
         border-left-color: hsl(0, 0%, 100%);
     }
 }
+
+.cd-timeline__date {
+    font-size: 16px;
+}
+
 @media (min-width: 64rem) {
     .cd-timeline__date {
         position: absolute;

--- a/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
+++ b/my_compassion/templates/components/my2_sponsor_child_timeline_batch.xml
@@ -51,7 +51,7 @@
                             </p>
                         </t>
                         <div class="flex justify-between items-center">
-                            <span class="cd-timeline__date">
+                            <span class="cd-timeline__date text-dark-blue">
                                 <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
@@ -86,7 +86,7 @@
                             </p>
                         </t>
                         <div class="flex justify-between items-center">
-                            <span class="cd-timeline__date">
+                            <span class="cd-timeline__date text-dark-blue">
                                 <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
@@ -111,7 +111,7 @@
                             <t t-esc="item['title']" />
                         </p>
                         <div class="flex justify-between items-center">
-                            <span class="cd-timeline__date">
+                            <span class="cd-timeline__date text-dark-blue">
                                 <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
@@ -128,7 +128,7 @@
                             <t t-esc="item['title']" />
                         </p>
                         <div class="flex justify-between items-center">
-                            <span class="cd-timeline__date">
+                            <span class="cd-timeline__date text-dark-blue">
                                 <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>
@@ -145,7 +145,7 @@
                             <t t-esc="item['title']" />
                         </p>
                         <div class="flex justify-between items-center">
-                            <span class="cd-timeline__date">
+                            <span class="cd-timeline__date text-dark-blue">
                                 <t t-esc="item['event_date']" t-options='{"widget": "date"}' />
                             </span>
                         </div>


### PR DESCRIPTION
- FIX: slightly increased the size of the timeline icons
- FIX: removed margin bottom from the price text in the donation event
- FIX: increased the size of the timeline event date
- FIX: tweaked the color of the timeline event date

## Child page
- Changed the color and size of the dates in the timeline

Before:
<img width="116" height="68" alt="16022026" src="https://github.com/user-attachments/assets/10bd1c89-d1aa-48d6-96e5-93b9e7d84212" />
After:
<img width="109" height="47" alt="16022026" src="https://github.com/user-attachments/assets/5c988dd8-c8c2-4dda-b52b-ab202aa7f4b8" />
- Removed excessive space from gift cards in the timeline

Before:
<img width="336" height="112" alt="Birthday gift" src="https://github.com/user-attachments/assets/10e3b213-0654-4bd8-83e0-097adf8fac00" />
After:
<img width="329" height="98" alt="Birthday gift" src="https://github.com/user-attachments/assets/416cc36b-2f7e-4417-b494-d74f569586ed" />