### PR TITLE
T3047 fix theme dependent redirections

### DIFF
--- a/my_compassion/controllers/my2_auth_signup.py
+++ b/my_compassion/controllers/my2_auth_signup.py
@@ -21,9 +21,11 @@ class SignupOverride(AuthSignupHome):
         Overrides the original signup page controller.
         Redirects logged-in users.
         """
-        # Check if a user ID exists in the current session
-        if request.session.uid:
-            return request.redirect("/my2/dashboard/")
+
+        if request.session.uid and request.website == request.env.ref(
+                "my_compassion.my2_website", raise_if_not_found=False
+        ):
+            return request.redirect(kw.get('redirect') or "/my2/dashboard/")
 
         # If the user is not logged in, execute the original Odoo logic for signup
         return super().web_auth_signup(*args, **kw)

--- a/my_compassion/controllers/my2_auth_signup.py
+++ b/my_compassion/controllers/my2_auth_signup.py
@@ -23,9 +23,9 @@ class SignupOverride(AuthSignupHome):
         """
 
         if request.session.uid and request.website == request.env.ref(
-                "my_compassion.my2_website", raise_if_not_found=False
+            "my_compassion.my2_website", raise_if_not_found=False
         ):
-            return request.redirect(kw.get('redirect') or "/my2/dashboard/")
+            return request.redirect(kw.get("redirect") or "/my2/dashboard/")
 
         # If the user is not logged in, execute the original Odoo logic for signup
         return super().web_auth_signup(*args, **kw)

--- a/my_compassion/controllers/my2_login.py
+++ b/my_compassion/controllers/my2_login.py
@@ -22,9 +22,14 @@ class WebsiteLoginRedirect(Website):
         If the user is already logged in, they are redirected immediately.
         """
         # Check if a user ID exists in the current session
-        if request.session.uid:
+        if (
+            request.session.uid
+            and request.website == request.env.ref(
+                "my_compassion.my2_website", raise_if_not_found=False
+            )
+        ):
             # If so, redirect the user to their account page or dashboard
-            return request.redirect("/my2/dashboard/")
+            return request.redirect(kw.get('redirect') or "/my2/dashboard/")
 
         # If the user is not logged in, execute the original Odoo logic for login
         return super().web_login(*args, **kw)

--- a/my_compassion/controllers/my2_login.py
+++ b/my_compassion/controllers/my2_login.py
@@ -22,14 +22,11 @@ class WebsiteLoginRedirect(Website):
         If the user is already logged in, they are redirected immediately.
         """
         # Check if a user ID exists in the current session
-        if (
-            request.session.uid
-            and request.website == request.env.ref(
-                "my_compassion.my2_website", raise_if_not_found=False
-            )
+        if request.session.uid and request.website == request.env.ref(
+            "my_compassion.my2_website", raise_if_not_found=False
         ):
             # If so, redirect the user to their account page or dashboard
-            return request.redirect(kw.get('redirect') or "/my2/dashboard/")
+            return request.redirect(kw.get("redirect") or "/my2/dashboard/")
 
         # If the user is not logged in, execute the original Odoo logic for login
         return super().web_login(*args, **kw)

--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -261,7 +261,7 @@ class MyAccountController(CustomerPortal):
         if request.website == request.env.ref(
             "my_compassion.my2_website", raise_if_not_found=False
         ):
-            return request.redirect("/my2/dashboard")
+            return request.redirect(redirect or "/my2/dashboard")
 
         return super().home(redirect=redirect, **post)
 

--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -258,7 +258,12 @@ class MyAccountController(CustomerPortal):
         From MyCompassion 2.0, we ensured a proper redirection
         for user using old links.
         """
-        return request.redirect("/my2/dashboard")
+        if request.website == request.env.ref(
+            "my_compassion.my2_website", raise_if_not_found=False
+        ):
+            return request.redirect("/my2/dashboard")
+
+        return super().home(redirect=redirect, **post)
 
     @route("/my/letter", type="http", auth="user", website=True)
     def redirect_old_my_letter(self, child_id=None, template_id=None, **kwargs):
@@ -313,7 +318,9 @@ class MyAccountController(CustomerPortal):
         From MyCompassion 2.0, we ensured a proper redirection
         for user using old links.
         """
-        if request.website.sudo().theme_id.name == 'theme_compassion_2025':
+        if request.website == request.env.ref(
+            "my_compassion.my2_website", raise_if_not_found=False
+        ):
             return request.redirect("/my2/user_settings")
 
         partner = request.env.user.partner_id

--- a/my_compassion/controllers/my_account.py
+++ b/my_compassion/controllers/my_account.py
@@ -8,6 +8,7 @@
 ##############################################################################
 import base64
 import secrets
+from datetime import datetime
 from os import path, remove
 from urllib.parse import urlencode
 from zipfile import ZipFile
@@ -312,7 +313,20 @@ class MyAccountController(CustomerPortal):
         From MyCompassion 2.0, we ensured a proper redirection
         for user using old links.
         """
-        return request.redirect("/my2/user_settings")
+        if request.website.sudo().theme_id.name == 'theme_compassion_2025':
+            return request.redirect("/my2/user_settings")
+
+        partner = request.env.user.partner_id
+        values = self._prepare_portal_layout_values()
+        values.update(
+            {
+                "partner": partner,
+            }
+        )
+
+        if privacy_policy == "accepted" and not partner.legal_agreement_date:
+            partner.legal_agreement_date = datetime.now()
+        return request.render("my_compassion.my_information_page_template", values)
 
     @route("/my/download/<source>", type="http", auth="user", website=True)
     def download_file(self, source, **kw):

--- a/theme_compassion_2025/views/template_header.xml
+++ b/theme_compassion_2025/views/template_header.xml
@@ -52,11 +52,9 @@
         <xpath expr="//div[hasclass('dropdown-menu')]" position="attributes">
             <attribute name="class" add="shadow-sm animation-drop language-selector__dropdown-menu" separator=" " />
         </xpath>
-
         <xpath expr="//button[hasclass('dropdown-toggle')]" position="attributes">
             <attribute name="class" separator=" " add="d-none" />
         </xpath>
-
         <xpath expr="//button[hasclass('dropdown-toggle')]" position="after">
             <t t-call="theme_compassion_2025.LanguageSelector">
                 <t t-set="variant" t-value="'compact'" />


### PR DESCRIPTION
## Description
This PR resolves a multi-website routing issue where `my_compassion` controllers were globally intercepting core Odoo portal routes (`/my`, `/web/login`, `/web/signup, '/my/information`). This global interception was breaking the portal and login experience for users on other websites like Muskathlon and TOGETHER.

## Changes Made
* **Isolated Redirects:** Added strict website checks (`request.env.ref("my_compassion.my2_website")`)
* **Safe Fallbacks:** Ensure that if the user is on Muskathlon or TOGETHER, the controllers safely fall back to `super()` method.
* **Preserved Routing:** The `?redirect=` parameter is handled as well.

## Impact
MyCompassion users will continue to be seamlessly directed to the 2.0 dashboard (`/my2/dashboard`), while users on all other websites will now correctly see their native Odoo portal views without issues. 