### PR TITLE
T3021 letter after termination

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.8"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,9 +125,7 @@ repos:
       rev: 3.1.8
       hooks:
           - id: setuptools-odoo-make-default
-            additional_dependencies: ["setuptools"]
           - id: setuptools-odoo-get-requirements
-            additional_dependencies: ["setuptools"]
             args:
                 - --output
                 - requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,9 @@ repos:
       rev: 3.1.8
       hooks:
           - id: setuptools-odoo-make-default
+            additional_dependencies: ["setuptools"]
           - id: setuptools-odoo-get-requirements
+            additional_dependencies: ["setuptools"]
             args:
                 - --output
                 - requirements.txt

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -325,8 +325,7 @@ class MyCompassionChildrenController(WebsiteChild):
             {
                 "active_sponsorships": sponsorships.filtered(
                     # all not terminated or terminated within grace period
-                    lambda s: s.state != "terminated"
-                    or (s.state == "terminated" and s.can_write_letter)
+                    lambda s: s.state != "terminated" or s.can_write_letter
                 ),
                 "ended_sponsorships": sponsorships.filtered(
                     # terminated and not within grace period, excluding specific end reasons

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -324,11 +324,14 @@ class MyCompassionChildrenController(WebsiteChild):
             "my_compassion.my2_children_page",
             {
                 "active_sponsorships": sponsorships.filtered(
-                    lambda s: s.state != "terminated" or s.sds_state == "sub_waiting"
+                    # all not terminated or terminated within grace period
+                    lambda s: s.state != "terminated" or
+                              (s.state == "terminated" and s.can_write_letter)
                 ),
                 "ended_sponsorships": sponsorships.filtered(
+                    # terminated and not within grace period, excluding specific end reasons
                     lambda s: s.state == "terminated"
-                    and s.sds_state != "sub_waiting"
+                    and not s.can_write_letter
                     and s.end_reason_id.name
                     not in ["Subreject", "Mistake from our staff"]
                 ),

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -325,8 +325,8 @@ class MyCompassionChildrenController(WebsiteChild):
             {
                 "active_sponsorships": sponsorships.filtered(
                     # all not terminated or terminated within grace period
-                    lambda s: s.state != "terminated" or
-                              (s.state == "terminated" and s.can_write_letter)
+                    lambda s: s.state != "terminated"
+                    or (s.state == "terminated" and s.can_write_letter)
                 ),
                 "ended_sponsorships": sponsorships.filtered(
                     # terminated and not within grace period, excluding specific end reasons

--- a/my_compassion/i18n/de.po
+++ b/my_compassion/i18n/de.po
@@ -4604,3 +4604,14 @@ msgid ""
 msgstr ""
 "Jahre alt\n"
 "                        <i class=\"icon-user01 bg-low-yellow mx-1\"/>"
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_children_card_component
+msgid "Awaiting substitute sponsorship"
+msgstr "Wartet auf eine Ersatzpatenschaft"
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
+msgid "Write a last letter"
+msgstr "Einen letzten Brief schreiben"

--- a/my_compassion/i18n/fr_CH.po
+++ b/my_compassion/i18n/fr_CH.po
@@ -4643,7 +4643,7 @@ msgstr "ans <i class=\"icon-user01 bg-low-yellow mx-1\"/>"
 #: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
 #: model_terms:ir.ui.view,arch_db:my_compassion.my2_children_card_component
 msgid "Awaiting substitute sponsorship"
-msgstr ""
+msgstr "En attente d'une reprise de parrainage"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page

--- a/my_compassion/i18n/fr_CH.po
+++ b/my_compassion/i18n/fr_CH.po
@@ -4550,3 +4550,14 @@ msgid ""
 "years old\n"
 "                        <i class=\"icon-user01 bg-low-yellow mx-1\"/>"
 msgstr "ans <i class=\"icon-user01 bg-low-yellow mx-1\"/>"
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_children_card_component
+msgid "Awaiting substitute sponsorship"
+msgstr ""
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
+msgid "Write a last letter"
+msgstr "Écrire une dernière lettre"

--- a/my_compassion/i18n/it.po
+++ b/my_compassion/i18n/it.po
@@ -4710,7 +4710,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
 #: model_terms:ir.ui.view,arch_db:my_compassion.my2_children_card_component
 msgid "Awaiting substitute sponsorship"
-msgstr ""
+msgstr "In attesa di una ripresa del sostegno"
 
 #. module: my_compassion
 #: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page

--- a/my_compassion/i18n/it.po
+++ b/my_compassion/i18n/it.po
@@ -4617,3 +4617,14 @@ msgid ""
 msgstr ""
 "anni\n"
 "                        <i class=\"icon-user01 bg-low-yellow mx-1\"/>"
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_children_card_component
+msgid "Awaiting substitute sponsorship"
+msgstr ""
+
+#. module: my_compassion
+#: model_terms:ir.ui.view,arch_db:my_compassion.my2_child_timeline_page
+msgid "Write a last letter"
+msgstr "Scrivere un'ultima lettera"

--- a/my_compassion/models/contracts.py
+++ b/my_compassion/models/contracts.py
@@ -10,6 +10,10 @@ class RecurringContract(models.Model):
     )
 
     def _compute_can_show_on_my_compassion(self):
+        """
+        Return if a contract is active or terminated,
+        or if the contract is new (not cancelled and without parent)
+        """
         for contract in self:
             contract.can_show_on_my_compassion = contract.state in [
                 "active",

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -41,10 +41,7 @@
                         Pending activation
                     </span>
                 </div>
-                <div
-                    class="small"
-                    t-if="sponsorship and sponsorship.state == 'terminated'"
-                >
+                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated'">
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Sponsorship ended
                     </span>

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -40,9 +40,14 @@
                         Pending activation
                     </span>
                 </div>
-                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated'">
+                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state != 'sub_waiting'">
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Sponsorship ended
+                    </span>
+                </div>
+                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state == 'sub_waiting'">
+                    <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
+                        Awaiting substitute sponsorship
                     </span>
                 </div>
                 <!-- Correspondence Status and info section -->

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -52,7 +52,11 @@
                     class="small"
                     t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state == 'sub_waiting'"
                 >
-                    <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
+                    <span
+                        class="badge bg-low-yellow"
+                        title="The sponsorship has ended, awaiting substitute sponsorship"
+                        aria-label="Sponsorship ended waiting for sub"
+                    >
                         Awaiting substitute sponsorship
                     </span>
                 </div>

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -42,29 +42,17 @@
                 </div>
                 <div
                     class="small"
-                    t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state != 'sub_waiting'"
+                    t-if="sponsorship and sponsorship.state == 'terminated'"
                 >
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Sponsorship ended
-                    </span>
-                </div>
-                <div
-                    class="small"
-                    t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state == 'sub_waiting'"
-                >
-                    <span
-                        class="badge bg-low-yellow"
-                        title="The sponsorship has ended, awaiting substitute sponsorship"
-                        aria-label="Sponsorship ended waiting for sub"
-                    >
-                        <t>Awaiting substitute sponsorship</t>
                     </span>
                 </div>
                 <!-- Correspondence Status and info section -->
                 <div class="body-small mt-3">
                     <div t-if="show_status" class="mb-3 pl-3 pr-3">
                         <span class="border-bottom border-2 border-high-orange">
-                            <t t-if="sponsorship_end_date">
+                            <t t-if="sponsorship_end_date and not sponsorship.can_write_letter">
                                 Sponsorship terminated on
                                 <t
                                     t-esc="sponsorship_end_date"

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -40,12 +40,18 @@
                         Pending activation
                     </span>
                 </div>
-                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state != 'sub_waiting'">
+                <div
+                    class="small"
+                    t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state != 'sub_waiting'"
+                >
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Sponsorship ended
                     </span>
                 </div>
-                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state == 'sub_waiting'">
+                <div
+                    class="small"
+                    t-if="sponsorship and sponsorship.state == 'terminated' and sponsorship.sds_state == 'sub_waiting'"
+                >
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Awaiting substitute sponsorship
                     </span>

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -57,7 +57,7 @@
                         title="The sponsorship has ended, awaiting substitute sponsorship"
                         aria-label="Sponsorship ended waiting for sub"
                     >
-                        Awaiting substitute sponsorship
+                        <t>Awaiting substitute sponsorship</t>
                     </span>
                 </div>
                 <!-- Correspondence Status and info section -->

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -174,21 +174,21 @@
                                 </div>
                             </div>
                         </div>
-                        <div t-if="is_sponsorship_terminated and compassion_child.can_i_write_letter" class="d-flex justify-content-center align-items-center mt-5 mb-2">
-                            <t
-                                    t-if="access_scope == 'sponsor'"
-                                    t-call="theme_compassion_2025.ThemedButtonComponent"
-                                >
-                                    <t t-set="variant" t-value="'compact'" />
-                                    <t t-set="variation" t-value="'hollow'" />
-                                    <t t-set="label">Write a farewell letter</t>
-                                    <t t-set="color" t-value="'core-blue'" />
-                                    <t t-set="text_color" t-value="'core-blue'" />
-                                    <t
-                                        t-set="href"
-                                        t-value="'/my2/children/letters/new' + '?child_id=' + str(compassion_child.id)"
-                                    />
-                                </t>
+                        <div
+                            t-if="is_sponsorship_terminated and compassion_child.can_i_write_letter"
+                            class="d-flex justify-content-center align-items-center mt-5 mb-2"
+                        >
+                            <t t-if="access_scope == 'sponsor'" t-call="theme_compassion_2025.ThemedButtonComponent">
+                                <t t-set="variant" t-value="'compact'" />
+                                <t t-set="variation" t-value="'hollow'" />
+                                <t t-set="label">Write a farewell letter</t>
+                                <t t-set="color" t-value="'core-blue'" />
+                                <t t-set="text_color" t-value="'core-blue'" />
+                                <t
+                                    t-set="href"
+                                    t-value="'/my2/children/letters/new' + '?child_id=' + str(compassion_child.id)"
+                                />
+                            </t>
                         </div>
                     </section>
                     <section t-if="not is_sponsorship_terminated" class="child-related-information tabs-component">

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -60,6 +60,17 @@
                                 </span>
                             </div>
                             <div
+                                t-if="access_scope == 'sponsor' and compassion_child.my_sponsorship_id.sds_state == 'sub_waiting'"
+                            >
+                                <span
+                                    class="badge bg-low-yellow"
+                                    title="Your sponsorship has ended"
+                                    aria-label="Sponsorship ended"
+                                >
+                                    Awaiting substitute sponsorship
+                                </span>
+                            </div>
+                            <div
                                 t-if="access_scope == 'sponsor' and compassion_child.my_sponsorship_id.state in ('draft', 'waiting', 'mandate')"
                             >
                                 <span
@@ -162,6 +173,22 @@
                                     </p>
                                 </div>
                             </div>
+                        </div>
+                        <div t-if="is_sponsorship_terminated and compassion_child.can_i_write_letter" class="d-flex justify-content-center align-items-center mt-5 mb-2">
+                            <t
+                                    t-if="access_scope == 'sponsor'"
+                                    t-call="theme_compassion_2025.ThemedButtonComponent"
+                                >
+                                    <t t-set="variant" t-value="'compact'" />
+                                    <t t-set="variation" t-value="'hollow'" />
+                                    <t t-set="label">Write a farewell letter</t>
+                                    <t t-set="color" t-value="'core-blue'" />
+                                    <t t-set="text_color" t-value="'core-blue'" />
+                                    <t
+                                        t-set="href"
+                                        t-value="'/my2/children/letters/new' + '?child_id=' + str(compassion_child.id)"
+                                    />
+                                </t>
                         </div>
                     </section>
                     <section t-if="not is_sponsorship_terminated" class="child-related-information tabs-component">

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -60,17 +60,6 @@
                                 </span>
                             </div>
                             <div
-                                t-if="access_scope == 'sponsor' and compassion_child.my_sponsorship_id.sds_state == 'sub_waiting'"
-                            >
-                                <span
-                                    class="badge bg-low-yellow"
-                                    title="The sponsorship has ended, awaiting substitute sponsorship"
-                                    aria-label="Sponsorship ended waiting for sub"
-                                >
-                                    <t>Awaiting substitute sponsorship</t>
-                                </span>
-                            </div>
-                            <div
                                 t-if="access_scope == 'sponsor' and compassion_child.my_sponsorship_id.state in ('draft', 'waiting', 'mandate')"
                             >
                                 <span

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -64,8 +64,8 @@
                             >
                                 <span
                                     class="badge bg-low-yellow"
-                                    title="Your sponsorship has ended"
-                                    aria-label="Sponsorship ended"
+                                    title="The sponsorship has ended, awaiting substitute sponsorship"
+                                    aria-label="Sponsorship ended waiting for sub"
                                 >
                                     Awaiting substitute sponsorship
                                 </span>

--- a/my_compassion/templates/pages/my2_child_timeline.xml
+++ b/my_compassion/templates/pages/my2_child_timeline.xml
@@ -67,7 +67,7 @@
                                     title="The sponsorship has ended, awaiting substitute sponsorship"
                                     aria-label="Sponsorship ended waiting for sub"
                                 >
-                                    Awaiting substitute sponsorship
+                                    <t>Awaiting substitute sponsorship</t>
                                 </span>
                             </div>
                             <div
@@ -181,7 +181,7 @@
                             <t t-if="access_scope == 'sponsor'" t-call="theme_compassion_2025.ThemedButtonComponent">
                                 <t t-set="variant" t-value="'compact'" />
                                 <t t-set="variation" t-value="'hollow'" />
-                                <t t-set="label">Write a farewell letter</t>
+                                <t t-set="label">Write a last letter</t>
                                 <t t-set="color" t-value="'core-blue'" />
                                 <t t-set="text_color" t-value="'core-blue'" />
                                 <t

--- a/my_compassion/templates/pages/my2_children.xml
+++ b/my_compassion/templates/pages/my2_children.xml
@@ -75,7 +75,7 @@ Would you like to bring hope to another child?
                             <t t-set="show_underline" t-value="True" />
                         </t>
                     </div>
-                    <div class="container-content d-flex flex-column align-items-center mb-5">
+                    <div class="container-content d-flex flex-column align-items-center mb-5 p-0 p-sm-3">
                         <div class="w-100 d-flex flex-column">
                             <div class="row justify-content-center">
                                 <t t-foreach="ended_sponsorships" t-as="sponsorship">

--- a/my_compassion/templates/pages/my2_new_letter.xml
+++ b/my_compassion/templates/pages/my2_new_letter.xml
@@ -44,7 +44,9 @@
                                     <!-- Loop through children_sponsored_by_partner -->
                                     <t t-foreach="sponsorship_ids" t-as="sponsorship">
                                         <!-- Shows only active sponsorships as selections -->
-                                        <t t-if="sponsorship.state == 'active' or (sponsorship.state == 'terminated' and sponsorship.child_id.can_i_write_letter)">
+                                        <t
+                                            t-if="sponsorship.state == 'active' or (sponsorship.state == 'terminated' and sponsorship.child_id.can_i_write_letter)"
+                                        >
                                             <option
                                                 t-att-value="sponsorship.child_id.id"
                                                 t-att-selected="'selected' if sponsorship.child_id.id == selected_child.id else None"

--- a/my_compassion/templates/pages/my2_new_letter.xml
+++ b/my_compassion/templates/pages/my2_new_letter.xml
@@ -44,7 +44,7 @@
                                     <!-- Loop through children_sponsored_by_partner -->
                                     <t t-foreach="sponsorship_ids" t-as="sponsorship">
                                         <!-- Shows only active sponsorships as selections -->
-                                        <t t-if="sponsorship.state == 'active'">
+                                        <t t-if="sponsorship.state == 'active' or (sponsorship.state == 'terminated' and sponsorship.child_id.can_i_write_letter)">
                                             <option
                                                 t-att-value="sponsorship.child_id.id"
                                                 t-att-selected="'selected' if sponsorship.child_id.id == selected_child.id else None"

--- a/theme_compassion_2025/views/template_header.xml
+++ b/theme_compassion_2025/views/template_header.xml
@@ -52,11 +52,9 @@
         <xpath expr="//div[hasclass('dropdown-menu')]" position="attributes">
             <attribute name="class" add="shadow-sm animation-drop language-selector__dropdown-menu" separator=" " />
         </xpath>
-
         <xpath expr="//button[hasclass('dropdown-toggle')]" position="attributes">
             <attribute name="class" separator=" " add="d-none" />
         </xpath>
-
         <xpath expr="//button[hasclass('dropdown-toggle')]" position="after">
             <t t-call="theme_compassion_2025.LanguageSelector">
                 <t t-set="variant" t-value="'compact'" />


### PR DESCRIPTION
- REFACTOR: Sponsorships remain in the active category 90 days after they have been terminated
- REFACTOR: the 'sub_waiting' status is no longer considered, remains internal
- REFACTOR: No 'awaiting substitute sponsorship' indicator, and termination date is not shown as long as the sponsorship is in the active section
- STYLE: added docstrings to compute_can_show_on_my_compassion