### PR TITLE
[T3072] FIX: clear donation item in case of abandoned cart

### DIFF
--- a/website_event_compassion/controllers/events_controller.py
+++ b/website_event_compassion/controllers/events_controller.py
@@ -169,6 +169,10 @@ class EventsController(Controller):
         if sale_order.state != "draft":
             request.session["sale_order_id"] = None
             sale_order = request.website.sale_get_order(force_create=True).sudo()
+        else:
+            # clear existing lines t prevent retaining abandoned donations
+            sale_order.order_line.unlink()
+
         product_id = event.odoo_event_id.donation_product_id.id
         sale_order.add_donation(product_id, amount, registration_id=registration.id)
         return request.redirect("/shop/checkout?express=1")


### PR DESCRIPTION
- FIX: If the same product (amount) is selected after a cart has been abandoned, the correct name is shown (order line is cleared)