### PR TITLE
T3096 sponsorship last letter

### DIFF
--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -113,7 +113,7 @@ class MyCompassionChildrenController(WebsiteChild):
         child = request.env["compassion.child"].sudo().browse(child_id)
         # Find sponsorships for this child where exit communication is still pending
         pending_sponsorships = child.sponsorship_ids.filtered(
-            lambda s: s.is_exit_communication_pending
+            "is_exit_communication_pending"
         )
 
         # 1. Get hidden contract IDs
@@ -409,7 +409,6 @@ class MyCompassionChildrenController(WebsiteChild):
                     # terminated and not within grace period, excluding specific end reasons and exit comm sent
                     lambda s: s.state == "terminated"
                     and not s.can_write_letter
-                    and s.end_reason_id.name
                     and not s.is_exit_communication_pending
                     and s.end_reason_id.name
                     not in ["Subreject", "Mistake from our staff"]

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -324,14 +324,17 @@ class MyCompassionChildrenController(WebsiteChild):
             "my_compassion.my2_children_page",
             {
                 "active_sponsorships": sponsorships.filtered(
-                    # all not terminated or terminated within grace period
-                    lambda s: s.state != "terminated" or s.can_write_letter
+                    # all not terminated or terminated within grace period or exit com not sent yet
+                    lambda s: s.state != "terminated"
+                    or s.can_write_letter
+                    or s.is_exit_communication_pending
                 ),
                 "ended_sponsorships": sponsorships.filtered(
-                    # terminated and not within grace period, excluding specific end reasons
+                    # terminated and not within grace period, excluding specific end reasons and exit com sent
                     lambda s: s.state == "terminated"
                     and not s.can_write_letter
                     and s.end_reason_id.name
+                    and not s.is_exit_communication_pending
                     not in ["Subreject", "Mistake from our staff"]
                 ),
                 "latest_correspondences_by_child_id": latest_corr_by_child,

--- a/my_compassion/controllers/my2_children.py
+++ b/my_compassion/controllers/my2_children.py
@@ -108,12 +108,51 @@ class MyCompassionChildrenController(WebsiteChild):
 
         return partner.ids
 
-    def _get_timeline_count(self, child_id, partner_ids):
+    def _get_hidden_timeline_ids(self, child_id):
+        """Finds final letters and contract events that should be hidden because exit comm is pending."""
+        child = request.env["compassion.child"].sudo().browse(child_id)
+        # Find sponsorships for this child where exit communication is still pending
+        pending_sponsorships = child.sponsorship_ids.filtered(
+            lambda s: s.is_exit_communication_pending
+        )
+
+        # 1. Get hidden contract IDs
+        hidden_contract_ids = tuple(pending_sponsorships.ids) or (0,)
+
+        if not pending_sponsorships:
+            return hidden_contract_ids, (0,)
+
+        # 2. Get hidden letter IDs
+        final_type = request.env.ref(
+            "sbc_compassion.correspondence_type_final", raise_if_not_found=False
+        )
+        if not final_type:
+            return hidden_contract_ids, (0,)
+
+        hidden_letters = (
+            request.env["correspondence"]
+            .sudo()
+            .search(
+                [
+                    ("child_id", "=", child_id),
+                    ("sponsorship_id", "in", pending_sponsorships.ids),
+                    ("communication_type_ids", "in", final_type.ids),
+                ]
+            )
+        )
+
+        hidden_letter_ids = tuple(hidden_letters.ids) or (0,)
+
+        return hidden_contract_ids, hidden_letter_ids
+
+    def _get_timeline_count(
+        self, child_id, partner_ids, hidden_letter_ids=(0,), hidden_contract_ids=(0,)
+    ):
         """Get total count of timeline records (correspondence + gifts + child_pictures + start + end)."""
         sql = """
             SELECT
                 (SELECT COUNT(*) FROM correspondence
-                 WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s))
+                 WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s) AND id NOT IN %(hidden_letter_ids)s)
                 +
                 (SELECT COUNT(*) FROM sponsorship_gift
                  WHERE child_id = %(child_id)s AND partner_id = ANY(%(partner_ids)s))
@@ -129,7 +168,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 (SELECT SUM(
                         CASE WHEN rc.start_date IS NOT NULL THEN 1 ELSE 0 END
                             +
-                        CASE WHEN rc.state = 'terminated' AND rc.end_date IS NOT NULL THEN 1 ELSE 0 END
+                        CASE WHEN rc.state = 'terminated' AND rc.end_date IS NOT NULL AND rc.id NOT IN %(hidden_contract_ids)s THEN 1 ELSE 0 END
                         ) as count
                 FROM recurring_contract rc
                 WHERE rc.child_id = %(child_id)s
@@ -141,11 +180,21 @@ class MyCompassionChildrenController(WebsiteChild):
             {
                 "child_id": child_id,
                 "partner_ids": partner_ids,
+                "hidden_letter_ids": hidden_letter_ids,
+                "hidden_contract_ids": hidden_contract_ids,
             },
         )
         return request.env.cr.fetchone()[0] or 0
 
-    def _get_timeline_data(self, child_id, partner_ids, offset, limit):
+    def _get_timeline_data(
+        self,
+        child_id,
+        partner_ids,
+        offset,
+        limit,
+        hidden_letter_ids=(0,),
+        hidden_contract_ids=(0,),
+    ):
         """Fetch paginated timeline records (correspondence + gifts) ordered by date."""
         # ruff: noqa: E501 (query is more readable this way)
         sql = """
@@ -170,6 +219,7 @@ class MyCompassionChildrenController(WebsiteChild):
                 FROM correspondence c
                 WHERE c.child_id = %(child_id)s
                   AND c.partner_id = ANY(%(partner_ids)s)
+                  AND c.id NOT IN %(hidden_letter_ids)s
                   -- Updated Filtering Logic
                   AND (
                       (c.state = 'Published to Global Partner' AND c.direction = 'Beneficiary To Supporter')
@@ -239,7 +289,7 @@ class MyCompassionChildrenController(WebsiteChild):
                   WHERE rc.child_id = %(child_id)s
                   AND rc.partner_id = ANY(%(partner_ids)s)
                   AND v.event_date IS NOT NULL
-                  AND (v.event_type = 'start_sponsorship' OR rc.state = 'terminated')
+                  AND (v.event_type = 'start_sponsorship' OR (rc.state = 'terminated' AND rc.id NOT IN %(hidden_contract_ids)s))
             ) AS timeline
             ORDER BY event_date DESC
             LIMIT %(limit)s OFFSET %(offset)s
@@ -247,6 +297,8 @@ class MyCompassionChildrenController(WebsiteChild):
         params = {
             "child_id": child_id,
             "partner_ids": partner_ids,
+            "hidden_letter_ids": hidden_letter_ids,
+            "hidden_contract_ids": hidden_contract_ids,
             "default_currency": request.env.user.currency_id.name,
             "title_corr_wrote": _("Wrote you a letter"),
             "title_corr_received": _("Received your letter"),
@@ -278,9 +330,14 @@ class MyCompassionChildrenController(WebsiteChild):
         """
         child = request.env["compassion.child"].browse(child_id)
         partner_ids = self._get_authorized_partner_ids(child)
+        hidden_contract_ids, hidden_letter_ids = self._get_hidden_timeline_ids(child_id)
 
-        total = self._get_timeline_count(child_id, partner_ids)
-        records = self._get_timeline_data(child_id, partner_ids, offset, limit)
+        total = self._get_timeline_count(
+            child_id, partner_ids, hidden_letter_ids, hidden_contract_ids
+        )
+        records = self._get_timeline_data(
+            child_id, partner_ids, offset, limit, hidden_letter_ids, hidden_contract_ids
+        )
 
         return records, total
 
@@ -296,17 +353,36 @@ class MyCompassionChildrenController(WebsiteChild):
         latest_corr_by_child = {}
         correspondences_table = request.env["correspondence"].sudo()
         children_sponsored_by_partner = partner.sponsorship_ids.child_id
+        domain = [
+            "|",
+            ("partner_id", "=", partner.id),
+            (
+                "child_id",
+                "in",
+                children_sponsored_by_partner.filtered("can_i_write_letter").ids,
+            ),
+            ("direction", "=", "Beneficiary To Supporter"),
+        ]
+
+        # Dynamically exclude final letters of pending exit communications
+        final_type = request.env.ref(
+            "sbc_compassion.correspondence_type_final", raise_if_not_found=False
+        )
+        pending_sponsorships = partner.sponsorship_ids.filtered(
+            "is_exit_communication_pending"
+        )
+        if final_type and pending_sponsorships:
+            domain.extend(
+                [
+                    "!",
+                    "&",  # NOT (A AND B)
+                    ("sponsorship_id", "in", pending_sponsorships.ids),
+                    ("communication_type_ids", "in", final_type.ids),
+                ]
+            )
+
         received_correspondences = correspondences_table.search(
-            [
-                "|",
-                ("partner_id", "=", partner.id),
-                (
-                    "child_id",
-                    "in",
-                    children_sponsored_by_partner.filtered("can_i_write_letter").ids,
-                ),
-                ("direction", "=", "Beneficiary To Supporter"),
-            ],
+            domain,
             order="create_date desc",
         )
 
@@ -324,17 +400,18 @@ class MyCompassionChildrenController(WebsiteChild):
             "my_compassion.my2_children_page",
             {
                 "active_sponsorships": sponsorships.filtered(
-                    # all not terminated or terminated within grace period or exit com not sent yet
+                    # all not terminated or terminated within grace period or exit comm not sent yet
                     lambda s: s.state != "terminated"
                     or s.can_write_letter
                     or s.is_exit_communication_pending
                 ),
                 "ended_sponsorships": sponsorships.filtered(
-                    # terminated and not within grace period, excluding specific end reasons and exit com sent
+                    # terminated and not within grace period, excluding specific end reasons and exit comm sent
                     lambda s: s.state == "terminated"
                     and not s.can_write_letter
                     and s.end_reason_id.name
                     and not s.is_exit_communication_pending
+                    and s.end_reason_id.name
                     not in ["Subreject", "Mistake from our staff"]
                 ),
                 "latest_correspondences_by_child_id": latest_corr_by_child,

--- a/my_compassion/controllers/my2_letters.py
+++ b/my_compassion/controllers/my2_letters.py
@@ -102,13 +102,30 @@ class MyCompassionCorrespondenceController(MyCompassionChildrenController):
             ),  # No problems
         ]
 
-        # Combine all domains
+        # 4. Combine all domains
         filter_domain = expression.AND(
             [
                 base_domain,
                 expression.OR([b2s_domain, s2b_domain]),
             ]
         )
+
+        # 5. Exclude final letters if exit communication is pending
+        final_type = request.env.ref(
+            "sbc_compassion.correspondence_type_final", raise_if_not_found=False
+        )
+        pending_sponsorships = partner.sponsorship_ids.filtered(
+            "is_exit_communication_pending"
+        )
+
+        if final_type and pending_sponsorships:
+            exclusion_domain = [
+                "!",
+                "&",
+                ("sponsorship_id", "in", pending_sponsorships.ids),
+                ("communication_type_ids", "in", final_type.ids),
+            ]
+            filter_domain = expression.AND([filter_domain, exclusion_domain])
 
         if child:
             try:

--- a/my_compassion/models/contracts.py
+++ b/my_compassion/models/contracts.py
@@ -9,6 +9,11 @@ class RecurringContract(models.Model):
         compute="_compute_can_show_on_my_compassion",
     )
 
+    is_exit_communication_pending = fields.Boolean(
+        string="Exit Communication Pending",
+        compute="_compute_is_exit_communication_pending",
+    )
+
     def _compute_can_show_on_my_compassion(self):
         """
         Return if a contract is active or terminated,
@@ -19,3 +24,32 @@ class RecurringContract(models.Model):
                 "active",
                 "terminated",
             ] or (contract.state != "cancelled" and not contract.parent_id)
+
+    def _compute_is_exit_communication_pending(self):
+        # Fetch the XML IDs of the Planned and Unplanned Exit communication configs
+        exit_configs = [
+            self.env.ref(
+                "partner_communication_compassion.lifecycle_child_planned_exit",
+                raise_if_not_found=False,
+            ),
+            self.env.ref(
+                "partner_communication_compassion.lifecycle_child_unplanned_exit",
+                raise_if_not_found=False,
+            ),
+        ]
+        config_ids = [c.id for c in exit_configs if c]
+
+        for contract in self:
+            if contract.state == "terminated" and config_ids:
+                # Check if there is an unfinished communication job for this contract
+                domain = [
+                    ("config_id", "in", config_ids),
+                    ("state", "in", ["pending", "processing", "failure"]),
+                    ("object_ids", "ilike", str(contract.id)),
+                ]
+                pending_jobs = self.env["partner.communication.job"].search_count(
+                    domain
+                )
+                contract.is_exit_communication_pending = pending_jobs > 0
+            else:
+                contract.is_exit_communication_pending = False

--- a/my_compassion/models/contracts.py
+++ b/my_compassion/models/contracts.py
@@ -45,7 +45,7 @@ class RecurringContract(models.Model):
                 domain = [
                     ("config_id", "in", config_ids),
                     ("state", "in", ["pending", "processing", "failure"]),
-                    ("object_ids", "ilike", str(contract.id)),
+                    ("object_ids", "=", str(contract.id)),
                 ]
                 pending_jobs = self.env["partner.communication.job"].search_count(
                     domain

--- a/my_compassion/models/contracts.py
+++ b/my_compassion/models/contracts.py
@@ -26,7 +26,9 @@ class RecurringContract(models.Model):
             ] or (contract.state != "cancelled" and not contract.parent_id)
 
     def _compute_is_exit_communication_pending(self):
-        # Fetch the XML IDs of the Planned and Unplanned Exit communication configs
+        self.is_exit_communication_pending = False
+
+        # Fetch the XML IDs of the Planned and Unplanned Exit configs
         exit_configs = [
             self.env.ref(
                 "partner_communication_compassion.lifecycle_child_planned_exit",
@@ -39,17 +41,27 @@ class RecurringContract(models.Model):
         ]
         config_ids = [c.id for c in exit_configs if c]
 
-        for contract in self:
-            if contract.state == "terminated" and config_ids:
-                # Check if there is an unfinished communication job for this contract
-                domain = [
-                    ("config_id", "in", config_ids),
-                    ("state", "in", ["pending", "processing", "failure"]),
-                    ("object_ids", "=", str(contract.id)),
-                ]
-                pending_jobs = self.env["partner.communication.job"].search_count(
-                    domain
-                )
-                contract.is_exit_communication_pending = pending_jobs > 0
-            else:
-                contract.is_exit_communication_pending = False
+        # Isolate only the contracts that need to be checked
+        terminated_contracts = self.filtered(lambda c: c.state == "terminated")
+
+        if config_ids and terminated_contracts:
+            domain = [
+                ("config_id", "in", config_ids),
+                ("state", "in", ["pending", "processing", "failure"]),
+            ]
+
+            # request only object_ids column
+            pending_jobs = self.env["partner.communication.job"].search_read(
+                domain, ["object_ids"]
+            )
+
+            # Parse the comma-separated strings into a flat set of individual IDs
+            pending_contract_ids = set()
+            for job in pending_jobs:
+                if job.get("object_ids"):
+                    job_ids = [i.strip() for i in job["object_ids"].split(",")]
+                    pending_contract_ids.update(job_ids)
+
+            for contract in terminated_contracts:
+                if str(contract.id) in pending_contract_ids:
+                    contract.is_exit_communication_pending = True

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -67,14 +67,18 @@ class Partner(models.Model):
     def _compute_is_sponsor(self):
         for partner in self:
             partner.is_sponsor = self.env["recurring.contract"].search_count(
-                [
-                    "|",
-                    ("partner_id", "=", partner.id),
-                    ("correspondent_id", "=", partner.id),
-                    ("state", "in", ["waiting", "active"]),
-                    ("child_id", "!=", False),
-                ],
-            )
+            [
+                "|",
+                ("partner_id", "=", partner.id),
+                ("correspondent_id", "=", partner.id),
+                "|",
+                ("state", "in", ["waiting", "active"]),
+                "&",
+                ("state", "=", "terminated"),
+                ("is_exit_communication_pending", "=", True),
+                ("child_id", "!=", False),
+            ]
+        ) > 0
 
     def _compute_is_ex_sponsor(self):
         """

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -65,22 +65,27 @@ class Partner(models.Model):
         return bool(correspondence)
 
     def _compute_is_sponsor(self):
+        all_contracts = self.env["recurring.contract"].search(
+            [
+                "|",
+                ("partner_id", "in", self.ids),
+                ("correspondent_id", "in", self.ids),
+                ("child_id", "!=", False),
+            ]
+        )
+        contracts_by_partner = {}
+        for c in all_contracts:
+            if c.partner_id:
+                contracts_by_partner.setdefault(c.partner_id.id, []).append(c)
+            if c.correspondent_id and c.correspondent_id != c.partner_id:
+                contracts_by_partner.setdefault(c.correspondent_id.id, []).append(c)
+
         for partner in self:
-            partner.is_sponsor = (
-                self.env["recurring.contract"].search_count(
-                    [
-                        "|",
-                        ("partner_id", "=", partner.id),
-                        ("correspondent_id", "=", partner.id),
-                        "|",
-                        ("state", "in", ["waiting", "active"]),
-                        "&",
-                        ("state", "=", "terminated"),
-                        ("is_exit_communication_pending", "=", True),
-                        ("child_id", "!=", False),
-                    ]
-                )
-                > 0
+            partner_contracts = contracts_by_partner.get(partner.id, [])
+            partner.is_sponsor = any(
+                c.state in ["waiting", "active"]
+                or (c.state == "terminated" and c.is_exit_communication_pending)
+                for c in partner_contracts
             )
 
     def _compute_is_ex_sponsor(self):

--- a/my_compassion/models/res_partner.py
+++ b/my_compassion/models/res_partner.py
@@ -66,19 +66,22 @@ class Partner(models.Model):
 
     def _compute_is_sponsor(self):
         for partner in self:
-            partner.is_sponsor = self.env["recurring.contract"].search_count(
-            [
-                "|",
-                ("partner_id", "=", partner.id),
-                ("correspondent_id", "=", partner.id),
-                "|",
-                ("state", "in", ["waiting", "active"]),
-                "&",
-                ("state", "=", "terminated"),
-                ("is_exit_communication_pending", "=", True),
-                ("child_id", "!=", False),
-            ]
-        ) > 0
+            partner.is_sponsor = (
+                self.env["recurring.contract"].search_count(
+                    [
+                        "|",
+                        ("partner_id", "=", partner.id),
+                        ("correspondent_id", "=", partner.id),
+                        "|",
+                        ("state", "in", ["waiting", "active"]),
+                        "&",
+                        ("state", "=", "terminated"),
+                        ("is_exit_communication_pending", "=", True),
+                        ("child_id", "!=", False),
+                    ]
+                )
+                > 0
+            )
 
     def _compute_is_ex_sponsor(self):
         """

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -41,7 +41,10 @@
                         Pending activation
                     </span>
                 </div>
-                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated' and not sponsorship.is_exit_communication_pending">
+                <div
+                    class="small"
+                    t-if="sponsorship and sponsorship.state == 'terminated' and not sponsorship.is_exit_communication_pending"
+                >
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Sponsorship ended
                     </span>
@@ -50,7 +53,9 @@
                 <div class="body-small mt-3">
                     <div t-if="show_status" class="mb-3 pl-3 pr-3">
                         <span class="border-bottom border-2 border-high-orange">
-                            <t t-if="sponsorship_end_date and not sponsorship.can_write_letter and not sponsorship.is_exit_communication_pending">
+                            <t
+                                t-if="sponsorship_end_date and not sponsorship.can_write_letter and not sponsorship.is_exit_communication_pending"
+                            >
                                 Sponsorship terminated on
                                 <t
                                     t-esc="sponsorship_end_date"

--- a/my_compassion/templates/components/my2_children_card.xml
+++ b/my_compassion/templates/components/my2_children_card.xml
@@ -41,7 +41,7 @@
                         Pending activation
                     </span>
                 </div>
-                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated'">
+                <div class="small" t-if="sponsorship and sponsorship.state == 'terminated' and not sponsorship.is_exit_communication_pending">
                     <span class="badge bg-low-yellow" title="Your sponsorship has ended" aria-label="Sponsorship ended">
                         Sponsorship ended
                     </span>
@@ -50,7 +50,7 @@
                 <div class="body-small mt-3">
                     <div t-if="show_status" class="mb-3 pl-3 pr-3">
                         <span class="border-bottom border-2 border-high-orange">
-                            <t t-if="sponsorship_end_date and not sponsorship.can_write_letter">
+                            <t t-if="sponsorship_end_date and not sponsorship.can_write_letter and not sponsorship.is_exit_communication_pending">
                                 Sponsorship terminated on
                                 <t
                                     t-esc="sponsorship_end_date"


### PR DESCRIPTION
- FIX: active/ended sponsorships new take into account if exit com was sent or not
- FIX: exit communication computation
- FIX: _compute_is_sponsor takes into account exit com
- FIX: child card also takes into account exit com
- FIX: Timeline elements now take into account exit comm
- FIX: final letters are not shown when exit comm is not sent yet