### PR TITLE
T3150 utm refactor

### DIFF
--- a/my_compassion/__manifest__.py
+++ b/my_compassion/__manifest__.py
@@ -114,6 +114,7 @@
         "auth_signup_verify_email",  # OCA/server-auth
         "queue_job",
         "theme_compassion_2025",
+        "utm",
     ],
     "demo": [],
     "installable": True,

--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -201,75 +201,28 @@ class MyCompassionSponsorshipsController(WebsiteChild):
 
 
 class MyCompassionNewSponsorshipController(http.Controller):
-    @staticmethod
-    def _extract_utm_information() -> dict:
-        """
-        Extracts utm medium, source and campaign information
-        from the session and returns it.
-        Return:
-            a dictionary containing utm information or empty dict
-        IMPORTANT:
-            the utms need to be created first, otherwise they
-            will be ignored!
-        """
-        utm_mapping = {
-            "wizard_utm_medium": ("utm.medium", "medium_id"),
-            "wizard_utm_source": ("utm.source", "source_id"),
-            "wizard_utm_campaign": ("utm.campaign", "campaign_id"),
-        }
-        session_vals = {k: request.session.get(k) for k in utm_mapping}
-        if any(session_vals.values()):
-            utm_vals = {}
-            for k, val in session_vals.items():
-                if val:
-                    model, f_id = utm_mapping[k]
-                    rec = (
-                        request.env[model]
-                        .sudo()
-                        .search([("name", "=ilike", val)], limit=1)
-                    )
-                    # only assign if campaign already exists
-                    if rec:
-                        utm_vals[f_id] = rec.id
-            # clean up the session variables
-            for k in utm_mapping:
-                request.session.pop(k, None)
-            return utm_vals
-        return {}
-
     @http.route(
-        "/my2/new-sponsorship/<int:child_id>",
+        '/my2/new-sponsorship/<model("compassion.child"):child>',
         type="http",
         auth="public",
         website=True,
     )
-    def wizard_start(self, child_id, sponsorship_type="standard", **kwargs):
+    def wizard_start(self, child, sponsorship_type="standard", **kwargs):
         """
         Renders the new sponsorship wizard initial page.
+
+        UTM tracking from query params is handled by Odoo's utm.mixin model.
+
         return: An HTTP response containing a rendered template
         with the initial wizard page.
         """
-        child = request.env["compassion.child"].sudo().browse(child_id)
-
-        if not child.exists():
-            raise NotFound("Child not found in database")
-
-        # capture and store utm information
-        utm_medium = kwargs.get("utm_medium")
-        utm_source = kwargs.get("utm_source")
-        utm_campaign = kwargs.get("utm_campaign")
-
-        if utm_medium:
-            request.session["wizard_utm_medium"] = utm_medium
-        if utm_source:
-            request.session["wizard_utm_source"] = utm_source
-        if utm_campaign:
-            request.session["wizard_utm_campaign"] = utm_campaign
-        # Make sure child is available and reserve it for 5 minutes
-        if child.state not in child._available_states():
+        child = child.sudo()
+        if not child.exists() or child.state not in child._available_states():
             raise NotFound()
+
+        # Reserve child for 5 minutes
         reservation_uuid = self._get_reservation_uuid()
-        if not child.sudo().reserve_for_web_sponsorship(reservation_uuid):
+        if not child.reserve_for_web_sponsorship(reservation_uuid):
             raise Gone()
 
         # Create new wizard
@@ -347,10 +300,6 @@ class MyCompassionNewSponsorshipController(http.Controller):
         if wizard.child_id.state not in wizard.child_id._available_states():
             raise Gone()
         sponsorship = wizard.finish_sponsorship()
-
-        utm_values = self._extract_utm_information()
-        if utm_values:
-            sponsorship.sudo().write(utm_values)
 
         # Redirect to thank-you page
         return request.redirect(

--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -8,6 +8,7 @@
 ##############################################################################
 import random
 import uuid
+from urllib.parse import urlencode
 
 from dateutil.relativedelta import relativedelta
 from werkzeug.exceptions import BadRequest, Gone, NotFound
@@ -354,6 +355,12 @@ class MyCompassionNewSponsorshipController(http.Controller):
         )
         currency_name = request.env.user.company_id.currency_id.name
 
+        # Send the user back to the exact URL they came from after login,
+        # preserving every query param (UTM, sponsorship_type, anything else).
+        login_url_redirect = (
+            f"/web/login?{urlencode({'redirect': request.httprequest.full_path})}"
+        )
+
         # Render step template first
         inner_step_html = request.env["ir.qweb"]._render(
             wizard.current_step.template,
@@ -365,6 +372,7 @@ class MyCompassionNewSponsorshipController(http.Controller):
                 "spoken_languages": spoken_languages,
                 "lead_sources": lead_sources,
                 "currency_name": currency_name,
+                "login_url_redirect": login_url_redirect,
             },
         )
 

--- a/my_compassion/models/contracts.py
+++ b/my_compassion/models/contracts.py
@@ -2,7 +2,15 @@ from odoo import fields, models
 
 
 class RecurringContract(models.Model):
-    _inherit = "recurring.contract"
+    """
+    Extends the recurring.contract model for MyCompassion features.
+
+    Inheriting "utm.mixin" makes sure that the model integrates Odoo's utm features.
+    This allows Odoo to automatically intercept UTM cookies.
+    """
+
+    _name = "recurring.contract"
+    _inherit = ["recurring.contract", "utm.mixin"]
 
     can_show_on_my_compassion = fields.Boolean(
         string="Can be shown on My Compassion",

--- a/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
+++ b/my_compassion/templates/pages/my2_new_sponsorship_wizard.xml
@@ -68,12 +68,7 @@ Page: My Compassion 2 New Sponsorship Wizard Page
     <template id="my2_new_sponsorship_wizard_user_details" name="New Sponsorship Wizard User Details Step">
         <div class="mb-3 p-3 rounded-lg bg-light-blue tiny-text">
             Already have an account?
-            <a
-                t-attf-href="/web/login?redirect=/my2/new-sponsorship/#{wizard.child_id.id}?sponsorship_type=#{wizard.sponsorship_type}"
-                class="tiny-text bold text-core-blue"
-            >
-                Log in
-            </a>
+            <a t-att-href="login_url_redirect" class="tiny-text bold text-core-blue">Log in</a>
         </div>
         <!-- Salutation -->
         <t t-call="theme_compassion_2025.FormFieldComponent">


### PR DESCRIPTION
## T3150: Refactor UTM Tracking (and fix WordPress sponsorships)
**LINKED TO PR:** https://github.com/CompassionCH/compassion-switzerland/pull/1753

Follow-up to T3090 (PR compassion-website #321  and  [compassion-switzerland #1751](https://github.com/CompassionCH/compassion-switzerland/pull/1751).

## The Issue
The initial UTM tracking implementation introduced a critical bug: 
- **Broken Route:** Changing the route converter from `<model>` to `<int>` broke our all QR printed slug based link.
- **Reinventing the Wheel:** The previous code manually extracted and wrote UTM parameters into the session and records, bypassing Odoo's built-in `utm.mixin` functionality which already handles all of this natively via cookies.

## The Solution (Refactored & Simplified)
This PR removes the redundant code and leans on Odoo's UTM utility. 

- **Restored the `<model("compassion.child"):child>` route:** This fixes the WordPress related links. It also ensures backward compatibility, meaning slug-based links and integer-based links will work.
- **Native Odoo UTM Tracking:** Removed the custom UTM extraction logic. Added explicit `utm.mixin` inheritance to `recurring.contract`. Now, Odoo automatically intercepts UTMs from the URL, stores them in cookies, and maps them to the contract upon creation.
- **Fixed Login Redirection:** UTMs and query parameters are no longer lost during the `/web/login` round-trip.
- **Safe QR Code Generation:** (In `compassion-switzerland`) Refactored the QR URL builder to use `urllib.parse.urlencode` for safer parameter construction.

Here is how it works:
<img width="1681" height="803" alt="image" src="https://github.com/user-attachments/assets/7ed9a114-0b12-470a-b004-baca361e4b95" />

The code has been tested locally on the different possibilities.