### PR TITLE
[T3219] FIX: stop AccessError log spam on public new-sponsorship links

### DIFF
--- a/my_compassion/controllers/my2_sponsorships.py
+++ b/my_compassion/controllers/my2_sponsorships.py
@@ -203,7 +203,7 @@ class MyCompassionSponsorshipsController(WebsiteChild):
 
 class MyCompassionNewSponsorshipController(http.Controller):
     @http.route(
-        '/my2/new-sponsorship/<model("compassion.child"):child>',
+        '/my2/new-sponsorship/<model_safe("compassion.child"):child>',
         type="http",
         auth="public",
         website=True,

--- a/my_compassion/models/ir_http.py
+++ b/my_compassion/models/ir_http.py
@@ -8,7 +8,9 @@ class SafeModelConverter(ModelConverter):
     record the public user cannot read does not raise AccessError."""
 
     def to_url(self, value):
-        return super().to_url(value.sudo())
+        if hasattr(value, "sudo"):
+            value = value.sudo()
+        return super().to_url(value)
 
 
 class IrHttp(models.AbstractModel):

--- a/my_compassion/models/ir_http.py
+++ b/my_compassion/models/ir_http.py
@@ -1,8 +1,22 @@
 from odoo import models
 
+from odoo.addons.website.models.ir_http import ModelConverter
+
+
+class SafeModelConverter(ModelConverter):
+    """Model converter that builds its slug URL with sudo, so slugifying a
+    record the public user cannot read does not raise AccessError."""
+
+    def to_url(self, value):
+        return super().to_url(value.sudo())
+
 
 class IrHttp(models.AbstractModel):
     _inherit = "ir.http"
+
+    @classmethod
+    def _get_converters(cls):
+        return {**super()._get_converters(), "model_safe": SafeModelConverter}
 
     @classmethod
     def _get_translation_frontend_modules_name(cls):


### PR DESCRIPTION
- /my2/new-sponsorship/<child> uses a model converter, so Odoo builds the canonical slug URL by reading child.display_name on every request — before the controller runs.
  - Public/portal users (crawlers, stale QR/WordPress links) can't read children that are no longer available → AccessError logged on every hit.


Fix
  - Added model_safe converter that builds the slug with sudo(), used on the new-sponsorship route.
  - No more error; slug and integer URLs both keep working.
  - The controller than should then return a 404